### PR TITLE
Sphinx docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ perf.data.old
 .vscode
 Cargo.lock
 .pytest_cache
+docs/_*
+
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,5 @@ perf.data.old
 Cargo.lock
 .pytest_cache
 docs/_*
-
 .DS_Store
+*.pyc

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,59 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(".."))
+
+
+# -- Project information -----------------------------------------------------
+
+project = "Y-Py"
+copyright = "2022, John Waidhofer"
+author = "John Waidhofer"
+
+# The full version, including alpha/beta/rc tags
+release = "0.2.2"
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = ["sphinx.ext.autodoc", "autoapi.extension"]
+
+autoapi_type = "python"
+autoapi_dirs = [".."]
+
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ["_templates"]
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = "sphinx_rtd_theme"
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ["_static"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,8 +19,8 @@ sys.path.insert(0, os.path.abspath(".."))
 # -- Project information -----------------------------------------------------
 
 project = "Y-Py"
-copyright = "2022, John Waidhofer"
-author = "John Waidhofer"
+copyright = "2022, Kevin Jahns, Bartosz Sypytkowski, John Waidhofer"
+author = "Kevin Jahns, Bartosz Sypytkowski, John Waidhofer"
 
 # The full version, including alpha/beta/rc tags
 release = "0.2.2"
@@ -31,7 +31,10 @@ release = "0.2.2"
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["autoapi.extension"]
+extensions = [
+    "autoapi.extension",
+    "sphinx.ext.napoleon",
+]
 
 autoapi_type = "python"
 autoapi_dirs = [".."]
@@ -45,8 +48,8 @@ templates_path = ["_templates"]
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "tests", "docs"]
-autoapi_ignore = exclude_patterns
 
+autoapi_ignore = exclude_patterns
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,10 +31,11 @@ release = "0.2.2"
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx.ext.autodoc", "autoapi.extension"]
+extensions = ["autoapi.extension"]
 
 autoapi_type = "python"
 autoapi_dirs = [".."]
+autoapi_file_patterns = ["*.pyi"]
 
 
 # Add any paths that contain templates here, relative to this directory.
@@ -43,7 +44,8 @@ templates_path = ["_templates"]
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "tests", "docs"]
+autoapi_ignore = exclude_patterns
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,14 +1,21 @@
-.. Y-Py documentation master file, created by
-   sphinx-quickstart on Mon Feb 14 23:40:39 2022.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
-Welcome to Y-Py's documentation!
+Y-Py Documentation
 ================================
+Y-Py is a high-performance CRDT that allows Python developers to easily synchronize state between processes. It is built on top of the Y-CRDT: a powerful distributed data type library written in Rust. With Y-Py, developers can make robust, eventually consistent applications that share state between users. All changes are automatically resolved across application instances, so your code can focus on representing state instead of synchronizing it. This shared state can go beyond Python programs, interfacing to web applications backed by Y-Wasm. This allows for seamless communication between frontend user interfaces and Python application logic.
+
+
 
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
+
+   installation
+   tutorial
+   license
+
+:card: foo
+
+
+
 
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,20 @@
+.. Y-Py documentation master file, created by
+   sphinx-quickstart on Mon Feb 14 23:40:39 2022.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to Y-Py's documentation!
+================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,8 +1,6 @@
 Y-Py Documentation
 ================================
-Y-Py is a high-performance CRDT that allows Python developers to easily synchronize state between processes. It is built on top of the Y-CRDT: a powerful distributed data type library written in Rust. With Y-Py, developers can make robust, eventually consistent applications that share state between users. All changes are automatically resolved across application instances, so your code can focus on representing state instead of synchronizing it. This shared state can go beyond Python programs, interfacing to web applications backed by Y-Wasm. This allows for seamless communication between frontend user interfaces and Python application logic.
-
-
+Y-Py is a high-performance CRDT that allows Python developers to easily synchronize state between processes. It is built on top of Y-CRDT: a powerful distributed data type library written in Rust. With Y-Py, developers can make robust, eventually consistent applications that share state between users. All changes are automatically resolved across application instances, so your code can focus on representing state instead of synchronizing it. This shared state can go beyond Python programs, interfacing to web applications backed by Y-Wasm. This allows for seamless communication between frontend user interfaces and Python application logic.
 
 .. toctree::
    :maxdepth: 2
@@ -11,8 +9,6 @@ Y-Py is a high-performance CRDT that allows Python developers to easily synchron
    installation
    tutorial
    license
-
-:card: foo
 
 
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,0 +1,7 @@
+Installation
+============
+You can install Y-Py from PyPI:
+
+.. code-block:: bash
+
+    pip install y_py

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1,0 +1,6 @@
+wheels
+======
+
+.. toctree::
+   :maxdepth: 4
+

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1,0 +1,28 @@
+Tutorial
+========
+
+Each user working with Y-Py data can read and update information through a shared document instance. Anything added to the document will be tracked and synchronized across all document instances. These documents can hold common data types, including numbers, booleans, strings, lists, dictionaries, and XML trees. Modifying the document state is done inside a transaction for robustness and thread safety. With these building blocks, you can safely share data between users. Here is a basic hello world example:
+
+.. code-block:: python
+
+    import y_py as Y
+
+    d1 = Y.YDoc()
+    # Create a new YText object in the YDoc
+    text = d1.get_text('test')
+    # Start a transaction in order to update the text
+    with d1.begin_transaction() as txn:
+        # Add text contents
+        text.push(txn, "hello world!")
+
+    # Create another document
+    d2 = Y.YDoc()
+    # Share state with the original document
+    state_vector = Y.encode_state_vector(d2)
+    diff = Y.encode_state_as_update(d1, state_vector)
+    Y.apply_update(d2, diff)
+
+    with d2.begin_transaction() as txn: 
+        value = d2.get_text('test').to_string(txn)
+
+    assert value == "hello world!"

--- a/y_py.pyi
+++ b/y_py.pyi
@@ -21,17 +21,16 @@ class YDoc:
     Document manages so called root types, which are top-level shared types definitions (as opposed
     to recursively nested types).
 
-    A basic workflow sample:
-    ```
-    from y_py import YDoc
+    Example::
 
-    doc = YDoc()
-    with doc.begin_transaction() as txn:
-        text = txn.get_text('name')
-        text.push(txn, 'hello world')
-        output = text.to_string(txn)
-        print(output)
-    ```
+        from y_py import YDoc
+
+        doc = YDoc()
+        with doc.begin_transaction() as txn:
+            text = txn.get_text('name')
+            text.push(txn, 'hello world')
+            output = text.to_string(txn)
+            print(output)
     """
 
     id: float
@@ -48,27 +47,29 @@ class YDoc:
         """
     def begin_transaction(self) -> YTransaction:
         """
-        Returns a new transaction for this document. y-py shared data types execute their
-        operations in a context of a given transaction. Each document can have only one active
-        transaction at the time - subsequent attempts will cause exception to be thrown.
+
+        Returns:
+            A new transaction for this document. y-py shared data types execute their
+            operations in a context of a given transaction. Each document can have only one active
+            transaction at the time - subsequent attempts will cause exception to be thrown.
 
         Transactions started with `doc.begin_transaction` can be released by deleting the transaction object
         method.
 
-        Example:
-        ```
-        from y_py import YDoc
-        doc = YDoc()
-        text = doc.get_text('name')
-        with doc.begin_transaction() as txn:
-            text.insert(txn, 0, 'hello world')
-        ```
+        Example::
+
+            from y_py import YDoc
+            doc = YDoc()
+            text = doc.get_text('name')
+            with doc.begin_transaction() as txn:
+                text.insert(txn, 0, 'hello world')
+
         """
     def transact(self, callback: Callable[[YTransaction]]): ...
     def get_map(self, name: str) -> YMap:
         """
-        Returns a `YMap` shared data type, that's accessible for subsequent accesses using given
-        `name`.
+        Returns:
+            A `YMap` shared data type, that's accessible for subsequent accesses using given `name`.
 
         If there was no instance with this name before, it will be created and then returned.
 
@@ -77,8 +78,8 @@ class YDoc:
         """
     def get_xml_element(self, name: str) -> YXmlElement:
         """
-        Returns a `YXmlElement` shared data type, that's accessible for subsequent accesses using
-        given `name`.
+        Returns:
+            A `YXmlElement` shared data type, that's accessible for subsequent accesses using given `name`.
 
         If there was no instance with this name before, it will be created and then returned.
 
@@ -87,8 +88,8 @@ class YDoc:
         """
     def get_xml_text(self, name: str) -> YXmlText:
         """
-        Returns a `YXmlText` shared data type, that's accessible for subsequent accesses using given
-        `name`.
+        Returns:
+            A `YXmlText` shared data type, that's accessible for subsequent accesses using given `name`.
 
         If there was no instance with this name before, it will be created and then returned.
 
@@ -97,8 +98,8 @@ class YDoc:
         """
     def get_array(self, name: str) -> YArray:
         """
-        Returns a `YArray` shared data type, that's accessible for subsequent accesses using given
-        `name`.
+        Returns:
+            A `YArray` shared data type, that's accessible for subsequent accesses using given `name`.
 
         If there was no instance with this name before, it will be created and then returned.
 
@@ -107,8 +108,12 @@ class YDoc:
         """
     def get_text(self, name: str) -> YText:
         """
-        Returns a `YText` shared data type, that's accessible for subsequent accesses using given
-        `name`.
+
+        Args:
+            name: The identifier for retreiving the text
+        Returns:
+            A `YText` shared data type, that's accessible for subsequent accesses using given `name`.
+
         If there was no instance with this name before, it will be created and then returned.
         If there was an instance with this name, but it was of different type, it will be projected
         onto `YText` instance.
@@ -121,21 +126,20 @@ def encode_state_vector(doc: YDoc) -> List[int]:
     can be used by `encode_state_as_update` on remote peer to generate a delta update payload to
     synchronize changes between peers.
 
-    Example:
+    Example::
 
-    ```
-    from y_py import YDoc, encode_state_vector, encode_state_as_update, apply_update from y_py
+        from y_py import YDoc, encode_state_vector, encode_state_as_update, apply_update from y_py
 
-    # document on machine A
-    local_doc = YDoc()
-    local_sv = encode_state_vector(local_doc)
+        # document on machine A
+        local_doc = YDoc()
+        local_sv = encode_state_vector(local_doc)
 
-    # document on machine B
-    remote_doc = YDoc()
-    remote_delta = encode_state_as_update(remote_doc, local_sv)
+        # document on machine B
+        remote_doc = YDoc()
+        remote_delta = encode_state_as_update(remote_doc, local_sv)
 
-    apply_update(local_doc, remote_delta)
-    ```
+        apply_update(local_doc, remote_delta)
+
     """
 
 def encode_state_as_update(doc: YDoc, vector: Optional[List[int]]) -> List[int]:
@@ -145,21 +149,19 @@ def encode_state_as_update(doc: YDoc, vector: Optional[List[int]]) -> List[int]:
     delta payload will contain all changes of a current y-py document, working effectively as its
     state snapshot.
 
-    Example:
+    Example::
 
-    ```
-    from y_py import YDoc, encode_state_vector, encode_state_as_update, apply_update
+        from y_py import YDoc, encode_state_vector, encode_state_as_update, apply_update
 
-    # document on machine A
-    local_doc = YDoc()
-    local_sv = encode_state_vector(local_doc)
+        # document on machine A
+        local_doc = YDoc()
+        local_sv = encode_state_vector(local_doc)
 
-    # document on machine B
-    remote_doc = YDoc()
-    remote_delta = encode_state_as_update(remote_doc, local_sv)
+        # document on machine B
+        remote_doc = YDoc()
+        remote_delta = encode_state_as_update(remote_doc, local_sv)
 
-    apply_update(local_doc, remote_delta)
-    ```
+        apply_update(local_doc, remote_delta)
     """
 
 def apply_update(doc: YDoc, diff: List[int]):
@@ -167,21 +169,19 @@ def apply_update(doc: YDoc, diff: List[int]):
     Applies delta update generated by the remote document replica to a current document. This
     method assumes that a payload maintains lib0 v1 encoding format.
 
-    Example:
+    Example::
 
-    ```
-    from y_py import YDoc, encode_state_vector, encode_state_as_update, apply_update
+        from y_py import YDoc, encode_state_vector, encode_state_as_update, apply_update
 
-    # document on machine A
-    local_doc = YDoc()
-    local_sv = encode_state_vector(local_doc)
+        # document on machine A
+        local_doc = YDoc()
+        local_sv = encode_state_vector(local_doc)
 
-    # document on machine B
-    remote_doc = YDoc()
-    remote_delta = encode_state_as_update(remote_doc, local_sv)
+        # document on machine B
+        remote_doc = YDoc()
+        remote_delta = encode_state_as_update(remote_doc, local_sv)
 
-    apply_update(local_doc, remote_delta)
-    ```
+        apply_update(local_doc, remote_delta)
     """
 
 class YTransaction:
@@ -193,21 +193,19 @@ class YTransaction:
     Transactions started with `doc.begin_transaction` can be released by deleting the transaction object
     method.
 
-    Example:
+    Example::
 
-    ```
-    from y_py import YDoc
-    doc = YDoc()
-    text = doc.get_text('name')
-    with doc.begin_transaction() as txn:
-        text.insert(txn, 0, 'hello world')
-    ```
+        from y_py import YDoc
+        doc = YDoc()
+        text = doc.get_text('name')
+        with doc.begin_transaction() as txn:
+            text.insert(txn, 0, 'hello world')
     """
 
     def get_text(self, name: str) -> YText:
         """
-        Returns a `YText` shared data type, that's accessible for subsequent accesses using given
-        `name`.
+        Returns:
+            A `YText` shared data type, that's accessible for subsequent accesses using given `name`.
 
         If there was no instance with this name before, it will be created and then returned.
 
@@ -216,8 +214,8 @@ class YTransaction:
         """
     def get_array(self, name: str) -> YArray:
         """
-        Returns a `YArray` shared data type, that's accessible for subsequent accesses using given
-        `name`.
+        Returns:
+            A `YArray` shared data type, that's accessible for subsequent accesses using given `name`.
 
         If there was no instance with this name before, it will be created and then returned.
 
@@ -226,8 +224,8 @@ class YTransaction:
         """
     def get_map(self, name: str) -> YMap:
         """
-        Returns a `YMap` shared data type, that's accessible for subsequent accesses using given
-        `name`.
+        Returns:
+            A `YMap` shared data type, that's accessible for subsequent accesses using given `name`.
 
         If there was no instance with this name before, it will be created and then returned.
 
@@ -247,28 +245,26 @@ class YTransaction:
         document and can be used by `encode_state_as_update` on remote peer to generate a delta
         update payload to synchronize changes between peers.
 
-        Example:
+        Example::
 
-        ```
-        from y_py import YDoc
+            from y_py import YDoc
 
-        # document on machine A
-        local_doc = YDoc()
-        local_txn = local_doc.begin_transaction()
+            # document on machine A
+            local_doc = YDoc()
+            local_txn = local_doc.begin_transaction()
 
-        # document on machine B
-        remote_doc = YDoc()
-        remote_txn = local_doc.begin_transaction()
+            # document on machine B
+            remote_doc = YDoc()
+            remote_txn = local_doc.begin_transaction()
 
-        try:
-            local_sv = local_txn.state_vector_v1()
-            remote_delta = remote_txn.diff_v1(local_sv)
-            local_txn.applyV1(remote_delta)
-        finally:
-            del local_txn
-            del remote_txn
+            try:
+                local_sv = local_txn.state_vector_v1()
+                remote_delta = remote_txn.diff_v1(local_sv)
+                local_txn.applyV1(remote_delta)
+            finally:
+                del local_txn
+                del remote_txn
 
-        ```
         """
     def diff_v1(self, vector: Optional[List[int]]) -> List[int]:
         """
@@ -277,54 +273,50 @@ class YTransaction:
         delta payload will contain all changes of a current y-py document, working effectively as
         its state snapshot.
 
-        Example:
+        Example::
 
-        ```
-        from y_py import YDoc
+            from y_py import YDoc
 
-        # document on machine A
-        local_doc = YDoc()
-        local_txn = local_doc.begin_transaction()
+            # document on machine A
+            local_doc = YDoc()
+            local_txn = local_doc.begin_transaction()
 
-        # document on machine B
-        remote_doc = YDoc()
-        remote_txn = local_doc.begin_transaction()
+            # document on machine B
+            remote_doc = YDoc()
+            remote_txn = local_doc.begin_transaction()
 
-        try:
-            local_sv = local_txn.state_vector_v1()
-            remote_delta = remote_txn.diff_v1(local_sv)
-            local_txn.applyV1(remote_delta)
-        finally:
-            del local_txn
-            del remote_txn
-        ```
+            try:
+                local_sv = local_txn.state_vector_v1()
+                remote_delta = remote_txn.diff_v1(local_sv)
+                local_txn.applyV1(remote_delta)
+            finally:
+                del local_txn
+                del remote_txn
         """
     def apply_v1(self, diff: List[int]):
         """
         Applies delta update generated by the remote document replica to a current transaction's
         document. This method assumes that a payload maintains lib0 v1 encoding format.
 
-        Example:
+        Example::
 
-        ```
-        from y_py import YDoc
+            from y_py import YDoc
 
-        # document on machine A
-        local_doc = YDoc()
-        local_txn = local_doc.begin_transaction()
+            # document on machine A
+            local_doc = YDoc()
+            local_txn = local_doc.begin_transaction()
 
-        # document on machine B
-        remote_doc = YDoc()
-        remote_txn = local_doc.begin_transaction()
+            # document on machine B
+            remote_doc = YDoc()
+            remote_txn = local_doc.begin_transaction()
 
-        try:
-            local_sv = local_txn.state_vector_v1()
-            remote_delta = remote_txn.diff_v1(local_sv)
-            local_txn.applyV1(remote_delta)
-        finally:
-            del local_txn
-            del remote_txn
-        ```
+            try:
+                local_sv = local_txn.state_vector_v1()
+                remote_delta = remote_txn.diff_v1(local_sv)
+                local_txn.applyV1(remote_delta)
+            finally:
+                del local_txn
+                del remote_txn
         """
     def __enter__() -> YTransaction: ...
     def __exit__() -> bool: ...
@@ -332,7 +324,7 @@ class YTransaction:
 class YText:
     """
     A shared data type used for collaborative text editing. It enables multiple users to add and
-    remove chunks of text in efficient manner. This type is internally represented as aable
+    remove chunks of text in efficient manner. This type is internally represented as able
     double-linked list of text chunks - an optimization occurs during `YTransaction.commit`, which
     allows to squash multiple consecutively inserted characters together as a single chunk of text
     even between transaction boundaries in order to preserve more efficient memory model.
@@ -359,11 +351,13 @@ class YText:
         """
     def to_string(self, txn: YTransaction) -> str:
         """
-        Returns an underlying shared string stored in this data type.
+        Returns:
+            The underlying shared string stored in this data type.
         """
     def to_json(self, txn: YTransaction) -> str:
         """
-        Returns an underlying shared string stored in this data type.
+        Returns:
+            The underlying shared string stored in this data type.
         """
     def insert(self, txn: YTransaction, index: int, chunk: str):
         """
@@ -410,27 +404,26 @@ class YArray:
         """
     def get(self, txn: YTransaction, index: int) -> Any:
         """
-        Returns an element stored under given `index`.
+        Returns:
+            The element stored under given `index`.
         """
     def values(self, txn: YTransaction) -> Iterator:
         """
-        Returns an iterator that can be used to traverse over the values stored withing this
-        instance of `YArray`.
+        Returns:
+            An iterator that can be used to traverse over the values stored withing this instance of `YArray`.
 
-        Example:
+        Example::
 
-        ```
-        from y_py import YDoc
+            from y_py import YDoc
 
-        # document on machine A
-        doc = YDoc()
-        array = doc.get_array('name')
+            # document on machine A
+            doc = YDoc()
+            array = doc.get_array('name')
 
-        with doc.begin_transaction() as txn:
-            array.push(txn, ['hello', 'world'])
-            for item in array.values(txn)):
-                print(item)
-        ```
+            with doc.begin_transaction() as txn:
+                array.push(txn, ['hello', 'world'])
+                for item in array.values(txn)):
+                    print(item)
         """
 
 class YMap:
@@ -460,28 +453,26 @@ class YMap:
         """
     def get(self, txn: YTransaction, key: str) -> Any | None:
         """
-        Returns value of an entry stored under given `key` within this instance of `YMap`,
-        or `None` if no such entry existed.
+        Returns:
+            Value of an entry stored under given `key` within this instance of `YMap`, or `None` if no such entry existed.
         """
     def entries(self, txn: YTransaction) -> Iterator:
         """
-        Returns an iterator that can be used to traverse over all entries stored within this
-        instance of `YMap`. Order of entry is not specified.
+        Returns:
+            An iterator that can be used to traverse over all entries stored within this instance of `YMap`. Order of entry is not specified.
 
-        Example:
+        Example::
 
-        ```
-        from y_py import YDoc
+            from y_py import YDoc
 
-        # document on machine A
-        doc = YDoc()
-        map = doc.get_map('name')
-        with doc.begin_transaction() as txn:
-            map.set(txn, 'key1', 'value1')
-            map.set(txn, 'key2', true)
-            for (key, value) in map.entries(txn)):
-                print(key, value)
-        ```
+            # document on machine A
+            doc = YDoc()
+            map = doc.get_map('name')
+            with doc.begin_transaction() as txn:
+                map.set(txn, 'key1', 'value1')
+                map.set(txn, 'key2', true)
+                for (key, value) in map.entries(txn)):
+                    print(key, value)
         """
 
 YXmlAttributes = Iterator[Tuple[str, str]]


### PR DESCRIPTION
Added Sphinx Documentation
- Created the `docs` folder to contain the .rst documentation files and build scripts
- Wrote a small package introduction, installation guide, and basic tutorial.
- Used `autoapi` to create documentation from the docstrings in the `y_py.pyi` types file
- Converted from Google Python documentation style to rst style using `napoleon`
- Rewrote the documentation to conform to Google Python documentation style.

## Testing
To test this out first install sphinx:
```
pip install Sphinx
```
Then navigate to the `docs` folder and run:
```
make html
```
This will produce a Sphinx build. Double click on `docs/_build/html/index` to preview the page.