### PR TITLE
Updated Ypy API for new Yrs version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,10 @@ name = "y_py"
 crate-type = ["cdylib"]
 
 [dependencies]
-yrs = "0.4.0"
-lib0 = "0.4.0"
+lib0 = "0.5.0"
+yrs = "0.5.0"
+
 
 [dependencies.pyo3]
-version = "0.14.5"
+version = "0.16.2"
 features = ["extension-module"]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Ypy is a Python binding for Y-CRDT. It provides distributed data types that enable real-time collaboration between devices. Ypy can sync data with any other platform that has a Y-CRDT binding, allowing for seamless cross-domain communication. The library is a thin wrapper around Yrs, taking advantage of the safety and performance of Rust.
 
+> 🧪 Project is still experimental. Expect the API to change before a version 1.0 stable release.
+
 ## Installation
 
 ```

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -22,7 +22,6 @@ Each user working with Ypy data can read and update information through a shared
     diff = Y.encode_state_as_update(d1, state_vector)
     Y.apply_update(d2, diff)
 
-    with d2.begin_transaction() as txn: 
-        value = d2.get_text('test').to_string(txn)
+    value = str(d2.get_text('test'))
 
     assert value == "hello world!"

--- a/src/y_array.rs
+++ b/src/y_array.rs
@@ -1,5 +1,5 @@
 use std::mem::ManuallyDrop;
-use std::ops::{Deref, DerefMut};
+use std::ops::DerefMut;
 
 use crate::type_conversions::insert_at;
 use crate::y_transaction::YTransaction;
@@ -8,7 +8,7 @@ use super::shared_types::SharedType;
 use crate::type_conversions::ToPython;
 use pyo3::exceptions::{PyIndexError, PyTypeError};
 use pyo3::prelude::*;
-use pyo3::types::PyList;
+use pyo3::types::{PyList, PySlice, PySliceIndices};
 use yrs::types::array::{ArrayEvent, ArrayIter};
 use yrs::{Array, Subscription, Transaction};
 
@@ -48,8 +48,28 @@ impl YArray {
     /// Once a preliminary instance has been inserted this way, it becomes integrated into Ypy
     /// document store and cannot be nested again: attempt to do so will result in an exception.
     #[new]
-    pub fn new(init: Option<Vec<PyObject>>) -> Self {
-        YArray(SharedType::prelim(init.unwrap_or_default()))
+    pub fn new(init: Option<PyObject>) -> PyResult<Self> {
+        let elements = if let Some(iterable) = init {
+            Python::with_gil(|py| {
+                iterable.as_ref(py).iter().map(|iterable| {
+                    iterable
+                        .map(|element| match element {
+                            Ok(value) => {
+                                let obj: PyObject = value.into();
+                                obj
+                            }
+                            Err(py_err) => {
+                                py_err.restore(py);
+                                py.None()
+                            }
+                        })
+                        .collect()
+                })
+            })
+        } else {
+            Ok(vec![])
+        };
+        elements.map(|el_array| YArray(SharedType::prelim(el_array)))
     }
 
     /// Returns true if this is a preliminary instance of `YArray`.
@@ -66,18 +86,25 @@ impl YArray {
     }
 
     /// Returns a number of elements stored within this instance of `YArray`.
-    #[getter]
-    pub fn length(&self) -> u32 {
+    pub fn __len__(&self) -> usize {
         match &self.0 {
-            SharedType::Integrated(v) => v.len(),
-            SharedType::Prelim(v) => v.len() as u32,
+            SharedType::Integrated(v) => v.len() as usize,
+            SharedType::Prelim(v) => v.len() as usize,
         }
     }
 
+    pub fn __str__(&self) -> String {
+        return self.to_json().to_string();
+    }
+
+    pub fn __repr__(&self) -> String {
+        format!("YArray({})", self.__str__())
+    }
+
     /// Converts an underlying contents of this `YArray` instance into their JSON representation.
-    pub fn to_json(&self, txn: &YTransaction) -> PyObject {
+    pub fn to_json(&self) -> PyObject {
         Python::with_gil(|py| match &self.0 {
-            SharedType::Integrated(v) => v.to_json(txn).into_py(py),
+            SharedType::Integrated(v) => v.to_json().into_py(py),
             SharedType::Prelim(v) => {
                 let py_ptrs: Vec<PyObject> = v.iter().cloned().collect();
                 py_ptrs.into_py(py)
@@ -103,7 +130,7 @@ impl YArray {
 
     /// Appends a range of `items` at the end of this `YArray` instance.
     pub fn push(&mut self, txn: &mut YTransaction, items: Vec<PyObject>) {
-        let index = self.length();
+        let index = self.__len__() as u32; // length guaranteed to be non negative
         self.insert(txn, index, items);
     }
 
@@ -118,27 +145,11 @@ impl YArray {
         }
     }
 
-    /// Returns an element stored under given `index`.
-    pub fn get(&self, txn: &YTransaction, index: u32) -> PyResult<PyObject> {
-        match &self.0 {
-            SharedType::Integrated(v) => {
-                if let Some(value) = v.get(txn, index) {
-                    Ok(Python::with_gil(|py| value.into_py(py)))
-                } else {
-                    Err(PyIndexError::new_err(
-                        "Index outside the bounds of an YArray",
-                    ))
-                }
-            }
-            SharedType::Prelim(v) => {
-                if let Some(value) = v.get(index as usize) {
-                    Ok(value.clone())
-                } else {
-                    Err(PyIndexError::new_err(
-                        "Index outside the bounds of an YArray",
-                    ))
-                }
-            }
+    pub fn __getitem__(&self, index: Index) -> PyResult<PyObject> {
+        // Apply index to the Array type
+        match index {
+            Index::Int(index) => self.get_element(self.normalize_index(index)),
+            Index::Slice(slice) => self.get_range(slice),
         }
     }
 
@@ -153,18 +164,15 @@ impl YArray {
     /// # document on machine A
     /// doc = YDoc()
     /// array = doc.get_array('name')
-    ///
-    /// with doc.begin_transaction() as txn:
-    ///     array.push(txn, ['hello', 'world'])
-    ///     for item in array.values(txn)):
+    /// for item in array.values()):
     ///         print(item)
+    ///     
     /// ```
-    pub fn values(&self, txn: &YTransaction) -> YArrayIterator {
+    pub fn __iter__(&self) -> YArrayIterator {
         let inner_iter = match &self.0 {
             SharedType::Integrated(v) => unsafe {
                 let this: *const Array = v;
-                let tx: *const Transaction = txn.deref() as *const _;
-                InnerYArrayIter::Integrated((*this).iter(tx.as_ref().unwrap()))
+                InnerYArrayIter::Integrated((*this).iter())
             },
             SharedType::Prelim(v) => unsafe {
                 let this: *const Vec<PyObject> = v;
@@ -196,6 +204,89 @@ impl YArray {
     }
 }
 
+impl YArray {
+    /// Gets a single element from a YArray.
+    fn get_element(&self, index: u32) -> PyResult<PyObject> {
+        match &self.0 {
+            SharedType::Integrated(v) => {
+                if let Some(value) = v.get(index as u32) {
+                    Ok(Python::with_gil(|py| value.into_py(py)))
+                } else {
+                    Err(PyIndexError::new_err(
+                        "Index outside the bounds of an YArray",
+                    ))
+                }
+            }
+            SharedType::Prelim(v) => {
+                if let Some(value) = v.get(index as usize) {
+                    Ok(value.clone())
+                } else {
+                    Err(PyIndexError::new_err(
+                        "Index outside the bounds of an YArray",
+                    ))
+                }
+            }
+        }
+    }
+
+    // Creates a new YArray from a range of values specified in a PySlice
+    fn get_range(&self, slice: &PySlice) -> PyResult<PyObject> {
+        let PySliceIndices {
+            start, stop, step, ..
+        } = slice.indices(self.__len__() as i64).unwrap();
+        println!("RANGE ( start: {}, stop: {}, step {} )", start, stop, step);
+        match &self.0 {
+            SharedType::Integrated(arr) => Python::with_gil(|py| {
+                if step < 0 {
+                    let step = step.abs() as usize;
+                    let (start, stop) = ((stop + 1) as u32, (start + 1) as u32);
+                    let values: Vec<PyObject> = (start..stop)
+                        .rev()
+                        .step_by(step)
+                        .map(|i| arr.get(i).unwrap())
+                        .map(|v| v.into_py(py))
+                        .collect();
+                    Ok(values.into_py(py))
+                } else {
+                    let values: Vec<PyObject> = ((start as u32)..(stop as u32))
+                        .step_by(step as usize)
+                        .map(|i| arr.get(i).unwrap())
+                        .map(|v| v.into_py(py))
+                        .collect();
+                    Ok(values.into_py(py))
+                }
+            }),
+            SharedType::Prelim(arr) => Python::with_gil(|py| {
+                if step < 0 {
+                    let step = step.abs() as usize;
+                    let (start, stop) = ((stop + 1) as usize, (start + 1) as usize);
+                    let list =
+                        PyList::new(py, arr[start..stop].iter().rev().step_by(step).cloned());
+                    Ok(list.into())
+                } else {
+                    let step = step as usize;
+                    let (start, stop) = (start as usize, stop as usize);
+                    let list = PyList::new(py, arr[start..stop].iter().step_by(step).cloned());
+                    Ok(list.into())
+                }
+            }),
+        }
+    }
+
+    fn normalize_index(&self, index: isize) -> u32 {
+        if index < 0 {
+            (self.__len__() as isize + index) as u32
+        } else {
+            index as u32
+        }
+    }
+}
+#[derive(FromPyObject)]
+pub enum Index<'a> {
+    Int(isize),
+    Slice(&'a PySlice),
+}
+
 enum InnerYArrayIter {
     Integrated(ArrayIter<'static>),
     Prelim(std::slice::Iter<'static, PyObject>),
@@ -210,6 +301,19 @@ impl Drop for YArrayIterator {
     }
 }
 
+impl Iterator for YArrayIterator {
+    type Item = PyObject;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.0.deref_mut() {
+            InnerYArrayIter::Integrated(iter) => {
+                Python::with_gil(|py| iter.next().map(|v| v.into_py(py)))
+            }
+            InnerYArrayIter::Prelim(iter) => iter.next().cloned(),
+        }
+    }
+}
+
 #[pymethods]
 impl YArrayIterator {
     pub fn __iter__(slf: PyRef<Self>) -> PyRef<Self> {
@@ -217,12 +321,7 @@ impl YArrayIterator {
     }
 
     pub fn __next__(mut slf: PyRefMut<Self>) -> Option<PyObject> {
-        match slf.0.deref_mut() {
-            InnerYArrayIter::Integrated(iter) => {
-                Python::with_gil(|py| iter.next().map(|v| v.into_py(py)))
-            }
-            InnerYArrayIter::Prelim(iter) => iter.next().cloned(),
-        }
+        slf.next()
     }
 }
 
@@ -274,7 +373,7 @@ impl YArrayEvent {
     /// Returns an array of keys and indexes creating a path from root type down to current instance
     /// of shared type (accessible via `target` getter).
     pub fn path(&self) -> PyObject {
-        Python::with_gil(|py| self.inner().path(self.txn()).into_py(py))
+        Python::with_gil(|py| self.inner().path().into_py(py))
     }
 
     /// Returns a list of text changes made over corresponding `YArray` collection within

--- a/src/y_array.rs
+++ b/src/y_array.rs
@@ -1,3 +1,4 @@
+use std::convert::TryInto;
 use std::mem::ManuallyDrop;
 use std::ops::DerefMut;
 
@@ -229,11 +230,11 @@ impl YArray {
         }
     }
 
-    // Creates a new YArray from a range of values specified in a PySlice
+    /// Creates a new YArray from a range of values specified in a PySlice
     fn get_range(&self, slice: &PySlice) -> PyResult<PyObject> {
         let PySliceIndices {
             start, stop, step, ..
-        } = slice.indices(self.__len__() as i64).unwrap();
+        } = slice.indices(self.__len__().try_into().unwrap()).unwrap();
         println!("RANGE ( start: {}, stop: {}, step {} )", start, stop, step);
         match &self.0 {
             SharedType::Integrated(arr) => Python::with_gil(|py| {

--- a/src/y_text.rs
+++ b/src/y_text.rs
@@ -2,6 +2,7 @@ use std::mem::ManuallyDrop;
 use std::ops::DerefMut;
 use std::str::Chars;
 
+use lib0::any::Any;
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 use pyo3::types::PyList;
@@ -108,7 +109,9 @@ impl YText {
 
     /// Returns an underlying shared string stored in this data type.
     pub fn to_json(&self) -> String {
-        self.__str__()
+        let mut json_string = String::new();
+        Any::String(self.__str__().into_boxed_str()).to_json(&mut json_string);
+        json_string
     }
 
     /// Inserts a given `chunk` of text into this `YText` instance, starting at a given `index`.

--- a/src/y_transaction.rs
+++ b/src/y_transaction.rs
@@ -216,12 +216,12 @@ impl YTransaction {
     /// ```
     fn __exit__<'p>(
         &'p mut self,
-        _exc_type: Option<&'p PyAny>,
-        _exc_value: Option<&'p PyAny>,
+        exception_type: Option<&'p PyAny>,
+        _exception_value: Option<&'p PyAny>,
         _traceback: Option<&'p PyAny>,
     ) -> PyResult<bool> {
         self.commit();
         drop(self);
-        return Ok(true);
+        Ok(exception_type.map_or_else(|| true, |_| false))
     }
 }

--- a/src/y_transaction.rs
+++ b/src/y_transaction.rs
@@ -222,6 +222,6 @@ impl YTransaction {
     ) -> PyResult<bool> {
         self.commit();
         drop(self);
-        Ok(exception_type.map_or_else(|| true, |_| false))
+        Ok(exception_type.map_or(true, |_| false))
     }
 }

--- a/tests/test_y_array.py
+++ b/tests/test_y_array.py
@@ -142,7 +142,7 @@ def test_borrow_mut_edge_case():
     with doc.begin_transaction() as txn:
         # Ensure that multiple mutable borrow functions can be called in a tight loop
         for i in range(2000):
-            arr.insert(txn, [1, 2, 3])
+            arr.insert(txn, 2, [1, 2, 3])
             arr.delete(txn, 0, 3)
 
 

--- a/tests/test_y_array.py
+++ b/tests/test_y_array.py
@@ -16,16 +16,23 @@ def test_inserts():
 
     expected = [1, 2.5, "hello", ["world"], True, {"key": "value"}]
 
-    value = d1.transact(lambda txn: x.to_json(txn))
-    assert value == expected  # TODO: Make this an arr cmp
+    value = x.to_json()
+    assert value == expected
 
     d2 = YDoc(2)
     x = d2.get_array("test")
 
     exchange_updates([d1, d2])
 
-    value = d2.transact(lambda txn: x.to_json(txn))
+    value = x.to_json()
     assert value == expected
+
+
+def test_to_string():
+    arr = YArray([7, "awesome", True, ["nested"], {"testing": "dicts"}])
+    expected_str = "[7, 'awesome', True, ['nested'], {'testing': 'dicts'}]"
+    assert str(arr) == expected_str
+    assert arr.__repr__() == f"YArray({expected_str})"
 
 
 def test_inserts_nested():
@@ -39,7 +46,7 @@ def test_inserts_nested():
 
     expected = [1, 2, ["hello", "world"], 3, 4]
 
-    value = d1.transact(lambda txn: x.to_json(txn))
+    value = d1.transact(lambda txn: x.to_json())
     assert value == expected
 
     d2 = YDoc()
@@ -47,7 +54,7 @@ def test_inserts_nested():
 
     exchange_updates([d1, d2])
 
-    value = d2.transact(lambda txn: x.to_json(txn))
+    value = x.to_json()
     assert value == expected
 
 
@@ -61,7 +68,7 @@ def test_delete():
 
     expected = [1, True]
 
-    value = d1.transact(lambda txn: x.to_json(txn))
+    value = x.to_json()
     assert value == expected
 
     d2 = YDoc(2)
@@ -69,49 +76,57 @@ def test_delete():
 
     exchange_updates([d1, d2])
 
-    value = d2.transact(lambda txn: x.to_json(txn))
+    value = x.to_json()
     assert value == expected
 
 
 def test_get():
     d1 = YDoc()
-    x = d1.get_array("test")
+    integrated = d1.get_array("test")
+    prelim = YArray()
 
-    d1.transact(lambda txn: x.insert(txn, 0, [1, 2, True]))
-    d1.transact(lambda txn: x.insert(txn, 1, ["hello", "world"]))
+    d1.transact(lambda txn: integrated.insert(txn, 0, [1, 2, True]))
+    d1.transact(lambda txn: integrated.insert(txn, 1, ["hello", "world"]))
 
-    zeroed = d1.transact(lambda txn: x.get(txn, 0))
-    first = d1.transact(lambda txn: x.get(txn, 1))
-    second = d1.transact(lambda txn: x.get(txn, 2))
-    third = d1.transact(lambda txn: x.get(txn, 3))
-    fourth = d1.transact(lambda txn: x.get(txn, 4))
+    expected = [1, "hello", "world", 2, True]
+    prelim = YArray(expected)
 
-    assert zeroed == 1
+    for arr in [integrated, prelim]:
+        # Forward indexing
+        for i, expected_value in enumerate(expected):
+            assert arr[i] == expected_value
 
-    assert first == "hello"
+        with pytest.raises(IndexError):
+            arr[5]
 
-    assert second == "world"
+        # Negative indexing
+        for i, expected_value in enumerate(reversed(expected)):
+            index = -(i + 1)
+            assert arr[index] == expected_value
 
-    assert third == 2
+        with pytest.raises(IndexError):
+            arr[-6]
 
-    assert fourth == True
-
-    with pytest.raises(IndexError):
-        x = d1.transact(lambda txn: x.get(txn, 20))
+        # Slices
+        assert arr[0:] == expected
+        assert arr[4:1:-1] == expected[4:1:-1]
+        assert arr[::-1] == expected[::-1]
 
 
 def test_iterator():
     d1 = YDoc()
     x = d1.get_array("test")
 
-    d1.transact(lambda txn: x.insert(txn, 0, [1, 2, 3]))
-    assert x.length == 3
-
     with d1.begin_transaction() as txn:
-        i = 1
-        for v in x.values(txn):
-            assert v == i
-            i += 1
+        x.insert(txn, 0, [1, 2, 3])
+    assert len(x) == 3
+    i = 1
+    # Test iteration
+    for v in x:
+        assert v == i
+        i += 1
+    # Test contains
+    assert 2 in x
 
 
 def test_borrow_mut_edge_case():
@@ -136,10 +151,6 @@ def test_observer():
 
     x = d1.get_array("test")
 
-    def get_value(x):
-        with d1.begin_transaction() as txn:
-            return x.to_json(txn)
-
     target = None
     delta = None
 
@@ -154,7 +165,7 @@ def test_observer():
     # insert initial data to an empty YArray
     with d1.begin_transaction() as txn:
         x.insert(txn, 0, [1, 2, 3, 4])
-    assert get_value(target) == get_value(x)
+    assert target.to_json() == x.to_json()
     assert delta == [{"insert": [1, 2, 3, 4]}]
 
     target = None
@@ -163,7 +174,7 @@ def test_observer():
     # remove 2 items from the middle
     with d1.begin_transaction() as txn:
         x.delete(txn, 1, 2)
-    assert get_value(target) == get_value(x)
+    assert target.to_json() == x.to_json()
     assert delta == [{"retain": 1}, {"delete": 2}]
 
     target = None
@@ -172,7 +183,7 @@ def test_observer():
     # insert  item in the middle
     with d1.begin_transaction() as txn:
         x.insert(txn, 1, [5])
-    assert get_value(target) == get_value(x)
+    assert target.to_json() == x.to_json()
     assert delta == [{"retain": 1}, {"insert": [5]}]
 
     target = None

--- a/tests/test_y_map.py
+++ b/tests/test_y_map.py
@@ -67,6 +67,8 @@ def test_iterator():
             v = expected[key]
             assert val == v
             del expected[key]
+
+        expected = {"a": 1, "b": 2, "c": 3}
         for key in x:
             assert key in expected
             assert key in x
@@ -80,7 +82,7 @@ def test_observer():
 
     def get_value(x):
         with d1.begin_transaction() as txn:
-            return x.to_json(txn)
+            return x.to_json()
 
     def callback(e):
         nonlocal target

--- a/tests/test_y_map.py
+++ b/tests/test_y_map.py
@@ -88,7 +88,7 @@ def test_observer():
         target = e.target
         entries = e.keys
 
-    observer = x.observe(callback)  # TODO: Fix typing
+    observer = x.observe(callback)
 
     # insert initial data to an empty YMap
     with d1.begin_transaction() as txn:

--- a/tests/test_y_map.py
+++ b/tests/test_y_map.py
@@ -1,19 +1,20 @@
 import y_py as Y
+from y_py import YMap
 
 
 def test_set():
     d1 = Y.YDoc()
     x = d1.get_map("test")
 
-    value = d1.transact(lambda txn: x.get(txn, "key"))
+    value = x["key"]
     assert value == None
 
     d1.transact(lambda txn: x.set(txn, "key", "value1"))
-    value = d1.transact(lambda txn: x.get(txn, "key"))
+    value = x["key"]
     assert value == "value1"
 
     d1.transact(lambda txn: x.set(txn, "key", "value2"))
-    value = d1.transact(lambda txn: x.get(txn, "key"))
+    value = x["key"]
     assert value == "value2"
 
 
@@ -27,7 +28,7 @@ def test_set_nested():
     d1.transact(lambda txn: x.set(txn, "key", nested))
     d1.transact(lambda txn: nested.set(txn, "b", "B"))
 
-    json = d1.transact(lambda txn: x.to_json(txn))
+    json = x.to_json()
     assert json == {"key": {"a": "A", "b": "B"}}
 
 
@@ -36,38 +37,39 @@ def test_delete():
     x = d1.get_map("test")
 
     d1.transact(lambda txn: x.set(txn, "key", "value1"))
-    len = d1.transact(lambda txn: x.length(txn))
-    value = d1.transact(lambda txn: x.get(txn, "key"))
-    assert len == 1
+    length = len(x)
+    value = x["key"]
+    assert length == 1
     assert value == "value1"
     d1.transact(lambda txn: x.delete(txn, "key"))
-    len = d1.transact(lambda txn: x.length(txn))
-    value = d1.transact(lambda txn: x.get(txn, "key"))
-    assert len == 0
+    length = len(x)
+    value = x["key"]
+    assert length == 0
     assert value == None
 
     d1.transact(lambda txn: x.set(txn, "key", "value2"))
-    len = d1.transact(lambda txn: x.length(txn))
-    value = d1.transact(lambda txn: x.get(txn, "key"))
-    assert len == 1
+    length = len(x)
+    value = x["key"]
+    assert length == 1
     assert value == "value2"
 
 
 def test_iterator():
-    d1 = Y.YDoc()
-    x = d1.get_map("test")
+    d = Y.YDoc()
+    x = d.get_map("test")
 
-    def test(txn):
+    with d.begin_transaction() as txn:
         x.set(txn, "a", 1)
         x.set(txn, "b", 2)
         x.set(txn, "c", 3)
         expected = {"a": 1, "b": 2, "c": 3}
-        for (key, val) in x.entries(txn):
+        for (key, val) in x.items():
             v = expected[key]
             assert val == v
             del expected[key]
-
-    d1.transact(test)
+        for key in x:
+            assert key in expected
+            assert key in x
 
 
 def test_observer():

--- a/tests/test_y_text.py
+++ b/tests/test_y_text.py
@@ -3,6 +3,33 @@ from test_helper import exchange_updates
 
 import y_py as Y
 
+from y_py import YText
+
+
+def test_to_string():
+    expected = "Hello World!"
+    d = Y.YDoc()
+    prelim = YText(expected)
+    integrated = d.get_text("test")
+    with d.begin_transaction() as txn:
+        integrated.push(txn, expected)
+    for test in [prelim, integrated]:
+        assert str(test) == expected
+        assert test.__repr__() == f"YText({expected})"
+
+
+def test_iteration():
+    expected = "Hello World!"
+    d = Y.YDoc()
+    prelim = YText(expected)
+    integrated = d.get_text("test")
+    with d.begin_transaction() as txn:
+        integrated.push(txn, expected)
+    for text in [integrated, prelim]:
+        assert "lo" in text
+        for actual, ex in zip(text, expected):
+            assert actual == ex
+
 
 def test_inserts():
     d1 = Y.YDoc()
@@ -10,16 +37,14 @@ def test_inserts():
     with d1.begin_transaction() as txn:
         x.push(txn, "hello ")
         x.push(txn, "world!")
-        value = x.to_string(txn)
+    value = str(x)
     expected = "hello world!"
     assert value == expected
 
     d2 = Y.YDoc(2)
     x = d2.get_text("test")
-
     exchange_updates([d1, d2])
-    with d2.begin_transaction() as txn:
-        value = x.to_string(txn)
+    value = str(x)
 
     assert value == expected
 
@@ -30,15 +55,15 @@ def test_deletes():
 
     d1.transact(lambda txn: x.push(txn, "hello world!"))
 
-    assert x.length == 12
+    assert len(x) == 12
     d1.transact(lambda txn: x.delete(txn, 5, 6))
-    assert x.length == 6
+    assert len(x) == 6
     d1.transact(lambda txn: x.insert(txn, 5, " Yrs"))
-    assert x.length == 10
+    assert len(x) == 10
 
     expected = "hello Yrs!"
 
-    value = d1.transact(lambda txn: x.to_string(txn))
+    value = str(x)
     assert value == expected
 
     d2 = Y.YDoc(2)
@@ -46,16 +71,12 @@ def test_deletes():
 
     exchange_updates([d1, d2])
 
-    value = d2.transact(lambda txn: x.to_string(txn))
+    value = str(x)
     assert value == expected
 
 
 def test_observer():
     d1 = Y.YDoc()
-
-    def get_value(x):
-        with d1.begin_transaction() as txn:
-            return x.to_string(txn)
 
     target = None
     delta = None
@@ -74,7 +95,7 @@ def test_observer():
     with d1.begin_transaction() as txn:
         x.insert(txn, 0, "abcd")
 
-    assert get_value(target) == get_value(x)
+    assert str(target) == str(x)
     assert delta == [{"insert": "abcd"}]
 
     target = None
@@ -84,7 +105,7 @@ def test_observer():
     with d1.begin_transaction() as txn:
         x.delete(txn, 1, 2)
 
-    assert get_value(target) == get_value(x)
+    assert str(target) == str(x)
     assert delta == [{"retain": 1}, {"delete": 2}]
     target = None
     delta = None
@@ -92,7 +113,7 @@ def test_observer():
     # insert item in the middle
     with d1.begin_transaction() as txn:
         x.insert(txn, 1, "e")
-    assert get_value(target) == get_value(x)
+    assert str(target) == str(x)
     assert delta == [{"retain": 1}, {"insert": "e"}]
     target = None
     delta = None

--- a/tests/test_y_text.py
+++ b/tests/test_y_text.py
@@ -17,19 +17,6 @@ def test_to_string():
         assert test.__repr__() == f"YText({expected})"
 
 
-def test_iteration():
-    expected = "Hello World!"
-    d = Y.YDoc()
-    prelim = YText(expected)
-    integrated = d.get_text("test")
-    with d.begin_transaction() as txn:
-        integrated.push(txn, expected)
-    for text in [integrated, prelim]:
-        assert "lo" in text
-        for actual, ex in zip(text, expected):
-            assert actual == ex
-
-
 def test_inserts():
     d1 = Y.YDoc()
     x = d1.get_text("test")

--- a/tests/test_y_text.py
+++ b/tests/test_y_text.py
@@ -1,13 +1,11 @@
-import pytest
 from test_helper import exchange_updates
-
 import y_py as Y
-
 from y_py import YText
 
 
 def test_to_string():
     expected = "Hello World!"
+    expected_json = '"Hello World!"'
     d = Y.YDoc()
     prelim = YText(expected)
     integrated = d.get_text("test")
@@ -15,6 +13,7 @@ def test_to_string():
         integrated.push(txn, expected)
     for test in [prelim, integrated]:
         assert str(test) == expected
+        assert test.to_json() == expected_json
         assert test.__repr__() == f"YText({expected})"
 
 

--- a/tests/test_y_xml.py
+++ b/tests/test_y_xml.py
@@ -5,112 +5,96 @@ import y_py as Y
 
 def test_insert():
     d1 = Y.YDoc()
-    root = d1.get_xml_element('test')
+    root = d1.get_xml_element("test")
     with d1.begin_transaction() as txn:
         b = root.push_xml_text(txn)
-        a = root.insert_xml_element(txn, 0, 'p')
+        a = root.insert_xml_element(txn, 0, "p")
         aa = a.push_xml_text(txn)
 
-        aa.push(txn, 'hello')
-        b.push(txn, 'world')
+        aa.push(txn, "hello")
+        b.push(txn, "world")
 
-        s = root.to_string(txn)
-    assert s == '<UNDEFINED><p>hello</p>world</UNDEFINED>'
+    s = str(root)
+    assert s == "<UNDEFINED><p>hello</p>world</UNDEFINED>"
+
 
 def test_attributes():
     d1 = Y.YDoc()
-    root = d1.get_xml_element('test')
+    root = d1.get_xml_element("test")
     with d1.begin_transaction() as txn:
-        root.set_attribute(txn, 'key1', 'value1')
-        root.set_attribute(txn, 'key2', 'value2')
+        root.set_attribute(txn, "key1", "value1")
+        root.set_attribute(txn, "key2", "value2")
 
         actual = {}
-        for key,value in root.attributes(txn):
+        for key, value in root.attributes():
             actual[key] = value
-    assert actual == {
-        "key1": 'value1',
-        "key2": 'value2'
-    }
+    assert actual == {"key1": "value1", "key2": "value2"}
 
     with d1.begin_transaction() as txn:
-        root.remove_attribute(txn, 'key1')
+        root.remove_attribute(txn, "key1")
         actual = {
-            "key1": root.get_attribute(txn, 'key1'),
-            "key2": root.get_attribute(txn, 'key2')
+            "key1": root.get_attribute("key1"),
+            "key2": root.get_attribute("key2"),
         }
 
-    assert actual == {
-        "key1": None,
-        "key2": 'value2'
-    }
+    assert actual == {"key1": None, "key2": "value2"}
 
 
 def test_siblings():
     d1 = Y.YDoc()
-    root = d1.get_xml_element('test')
+    root = d1.get_xml_element("test")
     with d1.begin_transaction() as txn:
         b = root.push_xml_text(txn)
-        a = root.insert_xml_element(txn, 0, 'p')
+        a = root.insert_xml_element(txn, 0, "p")
         aa = a.push_xml_text(txn)
 
-        aa.push(txn, 'hello')
-        b.push(txn, 'world')
+        aa.push(txn, "hello")
+        b.push(txn, "world")
         first = a
-        assert first.prev_sibling(txn) == None
+        assert first.prev_sibling == None
 
-    with d1.begin_transaction() as txn:
-        second = first.next_sibling(txn)
-        s = second.to_string(txn)
+        second = first.next_sibling
+        s = str(second)
         assert s == "world"
-        assert second.nextSibling(txn) == None
+        assert second.next_sibling == None
 
     with d1.begin_transaction() as txn:
-        actual = second.prev_sibling(txn).to_string(txn)
-        expected = first.to_string(txn)
+        actual = str(second.prev_sibling(txn))
+        expected = str(first)
         assert actual == expected
 
 
 def test_tree_walker():
     d1 = Y.YDoc()
-    root = d1.get_xml_element('test')
+    root = d1.get_xml_element("test")
     with d1.begin_transaction() as txn:
         b = root.push_xml_text(txn)
-        a = root.insert_xml_element(txn, 0, 'p')
+        a = root.insert_xml_element(txn, 0, "p")
         aa = a.push_xml_text(txn)
-        aa.push(txn, 'hello')
-        b.push(txn, 'world')
+        aa.push(txn, "hello")
+        b.push(txn, "world")
 
     with d1.begin_transaction() as txn:
         actual = []
-        for child in root.tree_walker(txn):
-            actual.push(child.to_string(txn))
+        for child in root.tree_walker():
+            actual.push(str(child))
 
-        expected = [
-            '<p>hello</p>',
-            'hello',
-            'world'
-        ]
+        expected = ["<p>hello</p>", "hello", "world"]
         assert actual == expected
 
     with d1.begin_transaction() as txn:
         actual = []
         for child in root.tree_walker(txn):
-            actual.push(child.to_string(txn))
+            actual.push(str(child))
 
-        expected = [
-            '<p>hello</p>',
-            'hello',
-            'world'
-        ]
+        expected = ["<p>hello</p>", "hello", "world"]
         assert actual == expected
 
 
 def test_xml_text_observer():
     d1 = Y.YDoc()
-    def get_value(x: Y.YXmlText) -> str:
-        with d1.begin_transaction() as txn:
-            return x.to_string(txn)
-    x = d1.get_xml_text('test')
+
+    x = d1.get_xml_text("test")
     target = None
     attributes = None
     delta = None
@@ -127,14 +111,14 @@ def test_xml_text_observer():
 
     # set initial attributes
     with d1.begin_transaction() as txn:
-        x.set_attribute(txn, 'attr1', 'value1')
-        x.set_attribute(txn, 'attr2', 'value2')
+        x.set_attribute(txn, "attr1", "value1")
+        x.set_attribute(txn, "attr2", "value2")
 
-    assert get_value(target) == get_value(x)
+    assert str(target) == str(x)
     assert delta == []
     assert attributes == {
-        "attr1": { "action": 'add', "newValue": 'value1' },
-        "attr2": { "action": 'add', "newValue": 'value2' }
+        "attr1": {"action": "add", "newValue": "value1"},
+        "attr2": {"action": "add", "newValue": "value2"},
     }
     target = None
     attributes = None
@@ -142,14 +126,14 @@ def test_xml_text_observer():
 
     # update attributes
     with d1.begin_transaction() as txn:
-        x.set_attribute(txn, 'attr1', 'value11')
-        x.remove_attribute(txn, 'attr2')
+        x.set_attribute(txn, "attr1", "value11")
+        x.remove_attribute(txn, "attr2")
 
-    assert get_value(target) == get_value(x)
+    assert str(target) == str(x)
     assert delta == []
     assert attributes == {
-        "attr1": { "action": 'update', "oldValue": 'value1', "newValue": 'value11' },
-        "attr2": { "action": 'delete', "oldValue": 'value2' }
+        "attr1": {"action": "update", "oldValue": "value1", "newValue": "value11"},
+        "attr2": {"action": "delete", "oldValue": "value2"},
     }
     target = None
     attributes = None
@@ -157,9 +141,9 @@ def test_xml_text_observer():
 
     # insert initial data to an empty YText
     with d1.begin_transaction() as txn:
-        x.insert(txn, 0, 'abcd')
-    assert get_value(target), get_value(x)
-    assert delta == [{"insert": "abcd"}] 
+        x.insert(txn, 0, "abcd")
+    assert str(target), str(x)
+    assert delta == [{"insert": "abcd"}]
     assert attributes == {}
     target = None
     attributes = None
@@ -167,8 +151,8 @@ def test_xml_text_observer():
     # remove 2 chars from the middle
     with d1.begin_transaction() as txn:
         x.delete(txn, 1, 2)
-    assert get_value(target) == get_value(x)
-    assert delta == [{"retain":1}, {"delete": 2}]
+    assert str(target) == str(x)
+    assert delta == [{"retain": 1}, {"delete": 2}]
     assert attributes == {}
     target = None
     attributes = None
@@ -176,9 +160,9 @@ def test_xml_text_observer():
 
     # insert item in the middle
     with d1.begin_transaction() as txn:
-        x.insert(txn, 1, 'e')
-    assert get_value(target) == get_value(x)
-    assert delta == [{"retain":1}, {"insert": 'e'}]
+        x.insert(txn, 1, "e")
+    assert str(target) == str(x)
+    assert delta == [{"retain": 1}, {"insert": "e"}]
     assert attributes == {}
     target = None
     attributes = None
@@ -186,43 +170,41 @@ def test_xml_text_observer():
 
     # free the observer and make sure that callback is no longer called
     del observer
-    with d1.begin_transaction() as txn: 
-        x.insert(txn, 1, 'fgh')
+    with d1.begin_transaction() as txn:
+        x.insert(txn, 1, "fgh")
     assert target == None
     assert attributes == None
     assert delta == None
 
+
 def test_xml_element_observer():
     d1 = Y.YDoc()
-    def get_value(x: Y.YXmlElement) -> str:
-        with d1.begin_transaction() as txn:
-            return x.to_string(txn)
 
-    x = d1.get_xml_element('test')
+    x = d1.get_xml_element("test")
     target = None
     attributes = None
     nodes = None
 
     def callback(e):
         nonlocal target
-        nonlocal attributes 
+        nonlocal attributes
         nonlocal nodes
         target = e.target
         attributes = e.keys
         nodes = e.delta
-    
+
     observer = x.observe(callback)
 
     # insert initial attributes
     with d1.begin_transaction() as txn:
-        x.set_attribute(txn, 'attr1', 'value1')
-        x.set_attribute(txn, 'attr2', 'value2')
+        x.set_attribute(txn, "attr1", "value1")
+        x.set_attribute(txn, "attr2", "value2")
 
-    assert get_value(target) == get_value(x)
+    assert str(target) == str(x)
     assert nodes == []
     assert attributes == {
-        "attr1": { "action": 'add', "newValue": 'value1' },
-        "attr2": { "action": 'add', "newValue": 'value2' }
+        "attr1": {"action": "add", "newValue": "value1"},
+        "attr2": {"action": "add", "newValue": "value2"},
     }
     target = None
     attributes = None
@@ -230,14 +212,14 @@ def test_xml_element_observer():
 
     # update attributes
     with d1.begin_transaction() as txn:
-        x.set_attribute(txn, 'attr1', 'value11')
-        x.remove_attribute(txn, 'attr2')
+        x.set_attribute(txn, "attr1", "value11")
+        x.remove_attribute(txn, "attr2")
 
-    assert get_value(target), get_value(x)
+    assert str(target), str(x)
     assert nodes == []
     assert attributes == {
-        "attr1": { "action": 'update', "oldValue": 'value1', "newValue": 'value11' },
-        "attr2": { "action": 'delete', "oldValue": 'value2' }
+        "attr1": {"action": "update", "oldValue": "value1", "newValue": "value11"},
+        "attr2": {"action": "delete", "oldValue": "value2"},
     }
 
     target = None
@@ -246,12 +228,12 @@ def test_xml_element_observer():
 
     # add children
     with d1.begin_transaction() as txn:
-        x.insert_xml_element(txn, 0, 'div')
-        x.insert_xml_element(txn, 1, 'p')
+        x.insert_xml_element(txn, 0, "div")
+        x.insert_xml_element(txn, 1, "p")
 
-    assert get_value(target) == get_value(x)
-    assert len(nodes[0]["insert"]) == 2 # [{ insert: [div, p] }
-    assert attributes ==  {}
+    assert str(target) == str(x)
+    assert len(nodes[0]["insert"]) == 2  # [{ insert: [div, p] }
+    assert attributes == {}
     target = None
     attributes = None
     nodes = None
@@ -259,8 +241,8 @@ def test_xml_element_observer():
     # remove a child
     with d1.begin_transaction() as txn:
         x.delete(txn, 0, 1)
-    assert get_value(target) == get_value(x)
-    assert nodes == [{ "delete": 1 }]
+    assert str(target) == str(x)
+    assert nodes == [{"delete": 1}]
     assert attributes == {}
     target = None
     attributes = None
@@ -268,12 +250,12 @@ def test_xml_element_observer():
 
     # insert child again
     with d1.begin_transaction() as txn:
-        txt = x.insert_xml_text(txn, x.length(txn))
+        txt = x.insert_xml_text(txn, len(x))
 
-    assert get_value(target) == get_value(x)
-    assert nodes[0] == { "retain": 1 }
+    assert str(target) == str(x)
+    assert nodes[0] == {"retain": 1}
     assert nodes[1]["insert"] != None
-    assert attributes ==  {}
+    assert attributes == {}
     target = None
     attributes = None
     nodes = None
@@ -281,7 +263,7 @@ def test_xml_element_observer():
     # free the observer and make sure that callback is no longer called
     del observer
     with d1.begin_transaction() as txn:
-        x.insert_xml_element(txn, 0, 'head')
+        x.insert_xml_element(txn, 0, "head")
     assert target == None
     assert nodes == None
     assert attributes == None

--- a/tests/test_y_xml.py
+++ b/tests/test_y_xml.py
@@ -58,10 +58,9 @@ def test_siblings():
         assert s == "world"
         assert second.next_sibling == None
 
-    with d1.begin_transaction() as txn:
-        actual = str(second.prev_sibling(txn))
-        expected = str(first)
-        assert actual == expected
+    actual = str(second.prev_sibling)
+    expected = str(first)
+    assert actual == expected
 
 
 def test_tree_walker():
@@ -77,15 +76,15 @@ def test_tree_walker():
     with d1.begin_transaction() as txn:
         actual = []
         for child in root.tree_walker():
-            actual.push(str(child))
+            actual.append(str(child))
 
         expected = ["<p>hello</p>", "hello", "world"]
         assert actual == expected
 
     with d1.begin_transaction() as txn:
         actual = []
-        for child in root.tree_walker(txn):
-            actual.push(str(child))
+        for child in root.tree_walker():
+            actual.append(str(child))
 
         expected = ["<p>hello</p>", "hello", "world"]
         assert actual == expected


### PR DESCRIPTION
Updated libraries and adapted Ypy API to be more Pythonic. The goal of the latter is to make Y types as interoperable as possible with native Python data structures without causing confusion.

## Changes
### Package Updates
- Updated PyO3 to 0.16.2
- Updated Yrs to 0.5.0

### Rust Ypy methods:
- Added `trait Iterator` to several internal type iterators for clarity
- Took out `YTransaction` argument for all read-only functions.
### YArray
Added native support for:
- Iteration: `[el for el in y_array]`
- Contains: `el in y_array`
- Number indexing: `y_array[0]`
- Range indexing: `y_array[1:3]`
- String `[1,2,3]` and Repr `YArray([1,2,3])` outputs for printing.
- Length operator `len(y_array)`

### YMap
- Key Iteration: `[key for key in y_map]`
- Key/Value iteration changed from `entries()` to `items()` to match Python dictionary API
- Contains: `key in y_map`
- Key indexing: `y_map["key"]`
- String `{"key": "value"}` and Repr `YMap({"key": "value"})` outputs for printing.
- Length operator `len(y_map)`

### YText
- Character Iteration: `[c for c in y_text]`
- Contains: `substring in y_text`
- String `"hello"` and Repr `YText("hello")` outputs for printing.
- Length operator `len(y_text)`

I recommend adding character and range indexing in another PR. The other option would just be converting first and then operating on the string:
```python
# with direct indexing
y_text[0:3] # does string casting and iteration internally

# Using the str method instead
string = str(y_text)
string[0:3]
```

### YXml Types
Made the following methods into getters:
- first_child: Optional[Xml]
- next_sibling: Optional[Xml]
- prev_sibling: Optional[Xml]
- parent: Optional[YXmlElement]

Added String an Repr methods similar to the ones above.

## Testing
Updated tests to handle new functionality

## Documentation
Updated docstrings and type hints for all methods


