### PR TITLE
Added update method

### DIFF
--- a/tests/test_y_map.py
+++ b/tests/test_y_map.py
@@ -1,3 +1,4 @@
+import pytest
 import y_py as Y
 from y_py import YMap
 
@@ -16,6 +17,34 @@ def test_set():
     d1.transact(lambda txn: x.set(txn, "key", "value2"))
     value = x["key"]
     assert value == "value2"
+
+
+def test_update():
+    doc = Y.YDoc()
+    ymap = doc.get_map("dict")
+    dict_vals = {"user_id": 1, "username": "Josh", "is_active": True}
+    tuple_vals = ((k, v) for k, v in dict_vals.items())
+
+    # Test updating with a dictionary
+    with doc.begin_transaction() as txn:
+        ymap.update(txn, dict_vals)
+    assert ymap.to_json() == dict_vals
+
+    # Test updating with an iterator
+    ymap = doc.get_map("tuples")
+    with doc.begin_transaction() as txn:
+        ymap.update(txn, tuple_vals)
+    assert ymap.to_json() == dict_vals
+
+    # Test non-string key error
+    with pytest.raises(Exception) as e:
+        with doc.begin_transaction() as txn:
+            ymap.update(txn, [(1, 2)])
+
+    # Test non-kv-tuple error
+    with pytest.raises(Exception) as e:
+        with doc.begin_transaction() as txn:
+            ymap.update(txn, [1])
 
 
 def test_set_nested():

--- a/y_py.pyi
+++ b/y_py.pyi
@@ -565,6 +565,13 @@ class YMap:
         Sets a given `key`-`value` entry within this instance of `YMap`. If another entry was
         already stored under given `key`, it will be overridden with new `value`.
         """
+    def update(self, txn: YTransaction, items: Iterable[Tuple[str, Any]]):
+        """
+        Updates `YMap` with the contents of items.
+        Args:
+            txn: A transaction to perform the insertion updates.
+            items: An iterable object that produces key value tuples to insert into the YMap
+        """
     def delete(self, txn: YTransaction, key: str):
         """
         Removes an entry identified by a given `key` from this instance of `YMap`, if such exists.


### PR DESCRIPTION
Fixes #27 
Added support for a YMap `update(txn, iterable)` function.
- The `iterable` argument supports both dictionaries and any iterable that yeilds key value tuples.
- Added `__dict__` method to display json contents of the `YMap`
- Added associated documentation and tests