### PR TITLE
added latest python to test and build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.7, ""] # Empty string will trigger a build with the latest python version
+        python-version: ["3.7", "3.10"] # Empty string will trigger a build with the latest python version
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: [3.7, ""] # Empty string will trigger a build with the latest python version
     defaults:
       run:
         shell: bash -l {0}
@@ -26,7 +27,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
-          python-version: "3.7"
+          python-version: ${{ matrix.python-version }}
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: [3.7, ""] # Empty string will trigger a build with the latest python version
+        python-version: ["3.7", "3.10"] # Empty string will trigger a build with the latest python version
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         target: [x64, x86]
-        python-version: [3.7, ""] # Empty string will trigger a build with the latest python version
+        python-version: ["3.7", "3.10"] # Empty string will trigger a build with the latest python version
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -78,7 +78,7 @@ jobs:
     strategy:
       matrix:
         target: [x86_64, i686]
-        python-version: [3.7, ""] # Empty string will trigger a build with the latest python version
+        python-version: ["3.7", "3.10"] # Empty string will trigger a build with the latest python version
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -10,16 +10,18 @@ concurrency:
 
 env:
   PACKAGE_NAME: y_py
-  PYTHON_VERSION: "3.8"
 
 jobs:
   macos:
     runs-on: macos-latest
+    strategy:
+      matrix:
+        python-version: [3.7, ""] # Empty string will trigger a build with the latest python version
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: ${{ matrix.python-version }}
           architecture: x64
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -47,11 +49,12 @@ jobs:
     strategy:
       matrix:
         target: [x64, x86]
+        python-version: [3.7, ""] # Empty string will trigger a build with the latest python version
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.target }}
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -75,11 +78,12 @@ jobs:
     strategy:
       matrix:
         target: [x86_64, i686]
+        python-version: [3.7, ""] # Empty string will trigger a build with the latest python version
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: ${{ matrix.python-version }}
           architecture: x64
       - name: Build wheels
         uses: messense/maturin-action@v1


### PR DESCRIPTION
Due to #36, we should support at least Python 3.10 in our test and build scripts. I updated the `test` and `wheels` actions to work with both Python 3.7 and ~Python-latest~ Python 3.10.

## Pros
- Provides an upper and lower bound for supported Python versions

## Cons
- ~Since the upper bound of the Python version is not pinned, it could lead to unexpected bugs when Anaconda updates their latest Python version.~