### PR TITLE
Allow to inherit from YDoc

### DIFF
--- a/src/y_doc.rs
+++ b/src/y_doc.rs
@@ -30,7 +30,7 @@ use crate::y_xml::YXmlText;
 ///     output = text.to_string(txn)
 ///     print(output)
 /// ```
-#[pyclass(unsendable)]
+#[pyclass(unsendable, subclass)]
 pub struct YDoc(pub Doc);
 
 #[pymethods]


### PR DESCRIPTION
I'm closing #38 and continuing the development of a Ypy websocket provider in https://github.com/davidbrochart/y-websocket.
But I will need to subclass YDoc, hence this PR.