### PR TITLE
Better Integration Error Messages

### DIFF
--- a/src/shared_types.rs
+++ b/src/shared_types.rs
@@ -5,7 +5,7 @@ use crate::{
     y_xml::{YXmlElement, YXmlText},
 };
 use pyo3::prelude::*;
-use std::convert::TryFrom;
+use std::{convert::TryFrom, fmt::Display};
 use yrs::types::TYPE_REFS_XML_ELEMENT;
 use yrs::types::TYPE_REFS_XML_TEXT;
 use yrs::types::{TypeRefs, TYPE_REFS_ARRAY, TYPE_REFS_MAP, TYPE_REFS_TEXT};
@@ -35,6 +35,19 @@ pub enum Shared {
     Map(Py<YMap>),
     XmlElement(Py<YXmlElement>),
     XmlText(Py<YXmlText>),
+}
+
+impl Display for Shared {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let str_repr = Python::with_gil(|py| match &self {
+            Shared::Text(text) => text.borrow(py).__str__(),
+            Shared::Array(arr) => arr.borrow(py).__str__(),
+            Shared::Map(map) => map.borrow(py).__str__(),
+            Shared::XmlElement(xml_el) => xml_el.borrow(py).__str__(),
+            Shared::XmlText(xml_text) => xml_text.borrow(py).__str__(),
+        });
+        write!(f, "{}", str_repr)
+    }
 }
 
 impl Shared {

--- a/src/type_conversions.rs
+++ b/src/type_conversions.rs
@@ -1,7 +1,10 @@
 use lib0::any::Any;
+use pyo3::create_exception;
+use pyo3::exceptions::PyException;
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 use pyo3::types as pytypes;
+
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::ops::Deref;
@@ -14,6 +17,8 @@ use crate::y_array::YArray;
 use crate::y_map::YMap;
 use crate::y_text::YText;
 use crate::y_xml::{YXmlElement, YXmlText};
+
+create_exception!(y_py, MultipleIntegrationError, PyException);
 
 pub trait ToPython {
     fn into_py(self, py: Python) -> PyObject;
@@ -149,7 +154,7 @@ impl Prelim for PyObjectWrapper {
                     let error_message = format!(
                         "Cannot integrate data that is already a part of another YDoc: {shared}"
                     );
-                    let type_error = PyTypeError::new_err(error_message);
+                    let type_error = MultipleIntegrationError::new_err(error_message);
                     type_error.restore(py);
                     panic!();
                 }
@@ -351,7 +356,7 @@ impl Prelim for PyValueWrapper {
                 let error_message = format!(
                     "Cannot integrate data that is already a part of another YDoc: {shared}"
                 );
-                let type_error = PyTypeError::new_err(error_message);
+                let type_error = MultipleIntegrationError::new_err(error_message);
                 Python::with_gil(|py| type_error.restore(py));
                 ItemContent::Any(Vec::new())
             }


### PR DESCRIPTION
Fixes #44 

Added more expressive error messages to the Prelim trait implementations
- Will raise a native Python error instead of throwing a panic

## Example
```python
d = Y.YDoc()
m = d.get_map("test")
d2 = Y.YDoc()
with d.begin_transaction() as txn:
        m.set(txn, "blah", 1)

container = d2.get_map("container")

with d2.begin_transaction() as txn:
        container.set(txn, "thisBreaks", m) # error happens here because `m` is already part of `d`
```
This results in the following error message:
> y_py.MultipleIntegrationError: Cannot integrate data that is already a part of another YDoc: {'blah': 1.0}