### PR TITLE
Deep Observe

### DIFF
--- a/src/shared_types.rs
+++ b/src/shared_types.rs
@@ -4,11 +4,42 @@ use crate::{
     y_text::YText,
     y_xml::{YXmlElement, YXmlText},
 };
-use pyo3::prelude::*;
+use pyo3::create_exception;
+use pyo3::{exceptions::PyException, prelude::*};
 use std::convert::TryFrom;
-use yrs::types::TYPE_REFS_XML_ELEMENT;
 use yrs::types::TYPE_REFS_XML_TEXT;
 use yrs::types::{TypeRefs, TYPE_REFS_ARRAY, TYPE_REFS_MAP, TYPE_REFS_TEXT};
+use yrs::{types::TYPE_REFS_XML_ELEMENT, SubscriptionId};
+
+// Common errors
+create_exception!(y_py, PreliminaryObservationException, PyException, "Occurs when an observer is attached to a Y type that is not integrated into a YDoc. Y types can only be observed once they have been added to a YDoc.");
+
+/// Creates a default error with a common message string for throwing a `PyErr`.
+pub(crate) trait DefaultPyErr {
+    /// Creates a new instance of the error with a default message.
+    fn default_message() -> PyErr;
+}
+
+impl DefaultPyErr for PreliminaryObservationException {
+    fn default_message() -> PyErr {
+        PreliminaryObservationException::new_err(
+            "Cannot observe a preliminary type. Must be added to a YDoc first",
+        )
+    }
+}
+
+#[pyclass]
+#[derive(Clone, Copy)]
+pub struct ShallowSubscription(pub SubscriptionId);
+#[pyclass]
+#[derive(Clone, Copy)]
+pub struct DeepSubscription(pub SubscriptionId);
+
+#[derive(FromPyObject)]
+pub enum SubId {
+    Shallow(ShallowSubscription),
+    Deep(DeepSubscription),
+}
 
 #[derive(Clone)]
 pub enum SharedType<T, P> {

--- a/src/y_array.rs
+++ b/src/y_array.rs
@@ -2,12 +2,15 @@ use std::convert::TryInto;
 use std::mem::ManuallyDrop;
 use std::ops::DerefMut;
 
+use crate::shared_types::{
+    DeepSubscription, DefaultPyErr, PreliminaryObservationException, ShallowSubscription, SubId,
+};
 use crate::type_conversions::{events_into_py, insert_at};
 use crate::y_transaction::YTransaction;
 
 use super::shared_types::SharedType;
 use crate::type_conversions::ToPython;
-use pyo3::exceptions::{PyIndexError, PyTypeError};
+use pyo3::exceptions::PyIndexError;
 use pyo3::prelude::*;
 use pyo3::types::{PyList, PySlice, PySliceIndices};
 use yrs::types::array::{ArrayEvent, ArrayIter};
@@ -187,47 +190,52 @@ impl YArray {
     /// Subscribes to all operations happening over this instance of `YArray`. All changes are
     /// batched and eventually triggered during transaction commit phase.
     /// Returns a `SubscriptionId` which can be used to cancel the callback with `unobserve`.
-    pub fn observe(&mut self, f: PyObject, deep: Option<bool>) -> PyResult<SubscriptionId> {
-        let deep = deep.unwrap_or(false);
+    pub fn observe(&mut self, f: PyObject) -> PyResult<ShallowSubscription> {
         match &mut self.0 {
-            SharedType::Integrated(array) if deep => {
-                let sub = array.observe_deep(move |txn, events| {
-                    Python::with_gil(|py| {
-                        let events = events_into_py(txn, events);
-                        if let Err(err) = f.call1(py, (events,)) {
-                            err.restore(py)
-                        }
-                    })
-                });
-                Ok(sub.into())
-            }
             SharedType::Integrated(array) => {
-                let sub = array.observe(move |txn, e| {
-                    Python::with_gil(|py| {
-                        let event = YArrayEvent::new(e, txn);
-                        if let Err(err) = f.call1(py, (event,)) {
-                            err.restore(py)
-                        }
+                let sub: SubscriptionId = array
+                    .observe(move |txn, e| {
+                        Python::with_gil(|py| {
+                            let event = YArrayEvent::new(e, txn);
+                            if let Err(err) = f.call1(py, (event,)) {
+                                err.restore(py)
+                            }
+                        })
                     })
-                });
-                Ok(sub.into())
+                    .into();
+                Ok(ShallowSubscription(sub))
             }
-            SharedType::Prelim(_) => Err(PyTypeError::new_err(
-                "Cannot observe a preliminary type. Must be added to a YDoc first",
-            )),
+            SharedType::Prelim(_) => Err(PreliminaryObservationException::default_message()),
+        }
+    }
+    /// Observes YArray events and events of all child elements.
+    pub fn observe_deep(&mut self, f: PyObject) -> PyResult<DeepSubscription> {
+        match &mut self.0 {
+            SharedType::Integrated(array) => {
+                let sub: SubscriptionId = array
+                    .observe_deep(move |txn, events| {
+                        Python::with_gil(|py| {
+                            let events = events_into_py(txn, events);
+                            if let Err(err) = f.call1(py, (events,)) {
+                                err.restore(py)
+                            }
+                        })
+                    })
+                    .into();
+                Ok(DeepSubscription(sub))
+            }
+            SharedType::Prelim(_) => Err(PreliminaryObservationException::default_message()),
         }
     }
 
     /// Cancels the callback of an observer using the Subscription ID returned from the `observe` method.
-    pub fn unobserve(&mut self, subscription_id: SubscriptionId) -> PyResult<()> {
+    pub fn unobserve(&mut self, subscription_id: SubId) -> PyResult<()> {
         match &mut self.0 {
-            SharedType::Integrated(v) => {
-                v.unobserve(subscription_id);
-                Ok(())
-            }
-            SharedType::Prelim(_) => Err(PyTypeError::new_err(
-                "Cannot call unobserve on a preliminary type. Must be added to a YDoc first",
-            )),
+            SharedType::Integrated(arr) => Ok(match subscription_id {
+                SubId::Shallow(ShallowSubscription(id)) => arr.unobserve(id),
+                SubId::Deep(DeepSubscription(id)) => arr.unobserve_deep(id),
+            }),
+            SharedType::Prelim(_) => Err(PreliminaryObservationException::default_message()),
         }
     }
 }

--- a/src/y_map.rs
+++ b/src/y_map.rs
@@ -8,7 +8,10 @@ use yrs::types::map::{MapEvent, MapIter};
 use yrs::types::DeepObservable;
 use yrs::{Map, SubscriptionId, Transaction};
 
-use crate::shared_types::SharedType;
+use crate::shared_types::{
+    DeepSubscription, DefaultPyErr, PreliminaryObservationException, ShallowSubscription,
+    SharedType, SubId,
+};
 use crate::type_conversions::{events_into_py, PyValueWrapper, ToPython};
 use crate::y_transaction::YTransaction;
 
@@ -206,45 +209,51 @@ impl YMap {
         YMapKeyIterator(self.items())
     }
 
-    pub fn observe(&mut self, f: PyObject, deep: Option<bool>) -> PyResult<SubscriptionId> {
-        let deep = deep.unwrap_or(false);
+    pub fn observe(&mut self, f: PyObject) -> PyResult<ShallowSubscription> {
         match &mut self.0 {
-            SharedType::Integrated(map) if deep => {
-                let sub = map.observe_deep(move |txn, events| {
-                    Python::with_gil(|py| {
-                        let events = events_into_py(txn, events);
-                        if let Err(err) = f.call1(py, (events,)) {
-                            err.restore(py)
-                        }
+            SharedType::Integrated(v) => {
+                let sub_id: SubscriptionId = v
+                    .observe(move |txn, e| {
+                        Python::with_gil(|py| {
+                            let e = YMapEvent::new(e, txn);
+                            if let Err(err) = f.call1(py, (e,)) {
+                                err.restore(py)
+                            }
+                        })
                     })
-                });
-                Ok(sub.into())
+                    .into();
+                Ok(ShallowSubscription(sub_id))
             }
-            SharedType::Integrated(v) => Ok(v
-                .observe(move |txn, e| {
-                    Python::with_gil(|py| {
-                        let e = YMapEvent::new(e, txn);
-                        if let Err(err) = f.call1(py, (e,)) {
-                            err.restore(py)
-                        }
+            SharedType::Prelim(_) => Err(PreliminaryObservationException::default_message()),
+        }
+    }
+
+    pub fn observe_deep(&mut self, f: PyObject) -> PyResult<DeepSubscription> {
+        match &mut self.0 {
+            SharedType::Integrated(map) => {
+                let sub: SubscriptionId = map
+                    .observe_deep(move |txn, events| {
+                        Python::with_gil(|py| {
+                            let events = events_into_py(txn, events);
+                            if let Err(err) = f.call1(py, (events,)) {
+                                err.restore(py)
+                            }
+                        })
                     })
-                })
-                .into()),
-            SharedType::Prelim(_) => Err(PyTypeError::new_err(
-                "Cannot observe a preliminary type. Must be added to a YDoc first",
-            )),
+                    .into();
+                Ok(DeepSubscription(sub))
+            }
+            SharedType::Prelim(_) => Err(PreliminaryObservationException::default_message()),
         }
     }
     /// Cancels the observer callback associated with the `subscripton_id`.
-    pub fn unobserve(&mut self, subscription_id: SubscriptionId) -> PyResult<()> {
+    pub fn unobserve(&mut self, subscription_id: SubId) -> PyResult<()> {
         match &mut self.0 {
-            SharedType::Integrated(map) => {
-                map.unobserve(subscription_id);
-                Ok(())
-            }
-            SharedType::Prelim(_) => Err(PyTypeError::new_err(
-                "Cannot unobserve a preliminary type. Must be added to a YDoc first",
-            )),
+            SharedType::Integrated(map) => Ok(match subscription_id {
+                SubId::Shallow(ShallowSubscription(id)) => map.unobserve(id),
+                SubId::Deep(DeepSubscription(id)) => map.unobserve_deep(id),
+            }),
+            SharedType::Prelim(_) => Err(PreliminaryObservationException::default_message()),
         }
     }
 }

--- a/src/y_text.rs
+++ b/src/y_text.rs
@@ -1,4 +1,7 @@
-use crate::shared_types::SharedType;
+use crate::shared_types::{
+    DeepSubscription, DefaultPyErr, PreliminaryObservationException, ShallowSubscription,
+    SharedType, SubId,
+};
 use crate::type_conversions::py_into_any;
 use crate::type_conversions::{events_into_py, ToPython};
 use crate::y_transaction::YTransaction;
@@ -11,7 +14,7 @@ use std::rc::Rc;
 use yrs::types::text::TextEvent;
 use yrs::types::Attrs;
 use yrs::types::DeepObservable;
-use yrs::{SubscriptionId, Text, Transaction};
+use yrs::{Text, Transaction};
 
 /// A shared data type used for collaborative text editing. It enables multiple users to add and
 /// remove chunks of text in efficient manner. This type is internally represented as a mutable
@@ -192,45 +195,53 @@ impl YText {
         }
     }
 
-    pub fn observe(&mut self, f: PyObject, deep: Option<bool>) -> PyResult<SubscriptionId> {
-        let deep = deep.unwrap_or(false);
+    /// Observes updates from the `YText` instance.
+    pub fn observe(&mut self, f: PyObject) -> PyResult<ShallowSubscription> {
         match &mut self.0 {
-            SharedType::Integrated(text) if deep => {
-                let sub = text.observe_deep(move |txn, events| {
-                    Python::with_gil(|py| {
-                        let events = events_into_py(txn, events);
-                        if let Err(err) = f.call1(py, (events,)) {
-                            err.restore(py)
-                        }
+            SharedType::Integrated(text) => {
+                let sub_id = text
+                    .observe(move |txn, e| {
+                        Python::with_gil(|py| {
+                            let e = YTextEvent::new(e, txn);
+                            if let Err(err) = f.call1(py, (e,)) {
+                                err.restore(py)
+                            }
+                        });
                     })
-                });
-                Ok(sub.into())
+                    .into();
+                Ok(ShallowSubscription(sub_id))
             }
-            SharedType::Integrated(v) => Ok(v
-                .observe(move |txn, e| {
-                    Python::with_gil(|py| {
-                        let e = YTextEvent::new(e, txn);
-                        if let Err(err) = f.call1(py, (e,)) {
-                            err.restore(py)
-                        }
-                    });
-                })
-                .into()),
-            SharedType::Prelim(_) => Err(PyTypeError::new_err(
-                "Cannot observe a preliminary type. Must be added to a YDoc first",
-            )),
+            SharedType::Prelim(_) => Err(PreliminaryObservationException::default_message()),
+        }
+    }
+
+    /// Observes updates from the `YText` instance and all of its nested children.
+    pub fn observe_deep(&mut self, f: PyObject) -> PyResult<DeepSubscription> {
+        match &mut self.0 {
+            SharedType::Integrated(text) => {
+                let sub = text
+                    .observe_deep(move |txn, events| {
+                        Python::with_gil(|py| {
+                            let events = events_into_py(txn, events);
+                            if let Err(err) = f.call1(py, (events,)) {
+                                err.restore(py)
+                            }
+                        })
+                    })
+                    .into();
+                Ok(DeepSubscription(sub))
+            }
+            SharedType::Prelim(_) => Err(PreliminaryObservationException::default_message()),
         }
     }
     /// Cancels the observer callback associated with the `subscripton_id`.
-    pub fn unobserve(&mut self, subscription_id: SubscriptionId) -> PyResult<()> {
+    pub fn unobserve(&mut self, subscription_id: SubId) -> PyResult<()> {
         match &mut self.0 {
-            SharedType::Integrated(text) => {
-                text.unobserve(subscription_id);
-                Ok(())
-            }
-            SharedType::Prelim(_) => Err(PyTypeError::new_err(
-                "Cannot unobserve a preliminary type. Must be added to a YDoc first",
-            )),
+            SharedType::Integrated(text) => Ok(match subscription_id {
+                SubId::Shallow(ShallowSubscription(id)) => text.unobserve(id),
+                SubId::Deep(DeepSubscription(id)) => text.unobserve_deep(id),
+            }),
+            SharedType::Prelim(_) => Err(PreliminaryObservationException::default_message()),
         }
     }
 }

--- a/tests/test_y_array.py
+++ b/tests/test_y_array.py
@@ -215,16 +215,16 @@ def test_deep_observe():
         nonlocal events
         events = e
 
-    sub = container.observe(callback, deep=True)
+    sub = container.observe_deep(callback)
     with ydoc.begin_transaction() as txn:
         container[0].push(txn, [3])
 
     assert events != None
 
     # Ensure that observer unsubscribes
-    # events = None
-    # container.unobserve(sub)
-    # with ydoc.begin_transaction() as txn:
-    #     container[0].push(txn, [4])
+    events = None
+    container.unobserve(sub)
+    with ydoc.begin_transaction() as txn:
+        container[0].push(txn, [4])
 
-    # assert events == None
+    assert events == None

--- a/tests/test_y_map.py
+++ b/tests/test_y_map.py
@@ -154,3 +154,26 @@ def test_observer():
         x.set(txn, "key1", [6])
     assert target == None
     assert entries == None
+
+
+def test_deep_observe():
+    """
+    Ensure that changes to elements inside the array trigger a callback.
+    """
+    doc = Y.YDoc()
+    container = doc.get_map("container")
+    inner_map = Y.YMap({"key": "initial"})
+    with doc.begin_transaction() as txn:
+        container.set(txn, "inner", inner_map)
+
+    events = None
+
+    def callback(e: list):
+        nonlocal events
+        events = e
+
+    container.observe(callback, deep=True)
+    with doc.begin_transaction() as txn:
+        container["inner"].set(txn, "addition", 1)
+
+    assert events != None

--- a/tests/test_y_map.py
+++ b/tests/test_y_map.py
@@ -172,8 +172,13 @@ def test_deep_observe():
         nonlocal events
         events = e
 
-    container.observe(callback, deep=True)
+    sub = container.observe_deep(callback)
     with doc.begin_transaction() as txn:
         container["inner"].set(txn, "addition", 1)
 
-    assert events != None
+    events = None
+    container.unobserve(sub)
+    with doc.begin_transaction() as txn:
+        container["inner"].set(txn, "don't show up", 1)
+
+    assert events is None

--- a/tests/test_y_text.py
+++ b/tests/test_y_text.py
@@ -203,7 +203,6 @@ def test_deep_observe():
     nested = Y.YMap({"bold": True})
     with d.begin_transaction() as txn:
         text.push(txn, "Hello")
-        text.insert_embed(txn, 0, nested)  # TODO how to observe?
     events = None
 
     def callback(e):
@@ -213,7 +212,9 @@ def test_deep_observe():
     sub = text.observe_deep(callback)
 
     with d.begin_transaction() as txn:
-        nested.set(txn, "new_attr", "value")
+        # Currently, Yrs does not support deep observe on embedded values.
+        # Deep observe will pick up the same events as shallow observe.
+        text.push(txn, " World")
 
     assert events is not None and len(events) == 1
 

--- a/tests/test_y_text.py
+++ b/tests/test_y_text.py
@@ -195,3 +195,32 @@ def test_formatting():
     assert delta == [{"retain": 4}, {"retain": 3, "attributes": {"bold": True}}]
 
     text.unobserve(sub)
+
+
+def test_deep_observe():
+    d = Y.YDoc()
+    text = d.get_text("text")
+    nested = Y.YMap({"bold": True})
+    with d.begin_transaction() as txn:
+        text.push(txn, "Hello")
+        text.insert_embed(txn, 0, nested)  # TODO how to observe?
+    events = None
+
+    def callback(e):
+        nonlocal events
+        events = e
+
+    sub = text.observe_deep(callback)
+
+    with d.begin_transaction() as txn:
+        nested.set(txn, "new_attr", "value")
+
+    assert events is not None and len(events) == 1
+
+    # verify that the subscription drops
+    events = None
+    text.unobserve(sub)
+    with d.begin_transaction() as txn:
+        nested.delete(txn, "new_attr")
+
+    assert events is None

--- a/tests/test_y_xml.py
+++ b/tests/test_y_xml.py
@@ -268,7 +268,7 @@ def test_deep_observe():
         nonlocal events
         events = e
 
-    sub = container.observe(callback, deep=True)
+    sub = container.observe_deep(callback)
     with ydoc.begin_transaction() as txn:
         container.first_child.push(txn, "nested")
 

--- a/tests/test_y_xml.py
+++ b/tests/test_y_xml.py
@@ -254,3 +254,22 @@ def test_xml_element_observer():
     assert target == None
     assert nodes == None
     assert attributes == None
+
+
+def test_deep_observe():
+    ydoc = Y.YDoc()
+    container = ydoc.get_xml_element("container")
+    with ydoc.begin_transaction() as txn:
+        text = container.insert_xml_text(txn, 0)
+
+    events = None
+
+    def callback(e: list):
+        nonlocal events
+        events = e
+
+    sub = container.observe(callback, deep=True)
+    with ydoc.begin_transaction() as txn:
+        container.first_child.push(txn, "nested")
+
+    assert events != None

--- a/y_py.pyi
+++ b/y_py.pyi
@@ -433,6 +433,8 @@ class YText:
     def observe_deep(self, f: Callable[[List[Event]]]) -> SubscriptionId:
         """
         Assigns a callback function to listen to the updates of the YText instance and those of its nested attributes.
+        Currently, this listens to the same events as YText.observe, but in the future this will also listen to
+        the events of embedded values.
 
         Args:
             f: Callback function that runs when the text object or its nested attributes receive an update.

--- a/y_py.pyi
+++ b/y_py.pyi
@@ -12,7 +12,11 @@ from typing import (
     Dict,
 )
 
-SubscriptionId = int
+class SubscriptionId:
+    """
+    Tracks an observer callback. Pass this to the `unobserve` method to cancel
+    its associated callback.
+    """
 
 Event = Union[YTextEvent, YArrayEvent, YMapEvent, YXmlTextEvent, YXmlElementEvent]
 
@@ -417,15 +421,21 @@ class YText:
         Deletes a specified range of of characters, starting at a given `index`.
         Both `index` and `length` are counted in terms of a number of UTF-8 character bytes.
         """
-    def observe(
-        self, f: Callable[[Union[YTextEvent, List[Event]]]], deep: bool = False
-    ) -> SubscriptionId:
+    def observe(self, f: Callable[[YTextEvent]]) -> SubscriptionId:
         """
         Assigns a callback function to listen to YText updates.
 
         Args:
             f: Callback function that runs when the text object receives an update.
-            deep: Determines whether the callback is triggered when embedded elements are changed.
+        Returns:
+            A reference to the callback subscription.
+        """
+    def observe_deep(self, f: Callable[[List[Event]]]) -> SubscriptionId:
+        """
+        Assigns a callback function to listen to the updates of the YText instance and those of its nested attributes.
+
+        Args:
+            f: Callback function that runs when the text object or its nested attributes receive an update.
         Returns:
             A reference to the callback subscription.
         """
@@ -523,15 +533,21 @@ class YArray:
             for item in array:
                 print(item)
         """
-    def observe(
-        self, f: Callable[[Union[YArrayEvent, List[Event]]]], deep: bool = False
-    ) -> SubscriptionId:
+    def observe(self, f: Callable[[YArrayEvent]]) -> SubscriptionId:
         """
         Assigns a callback function to listen to YArray updates.
 
         Args:
             f: Callback function that runs when the array object receives an update.
-            deep: Determines whether observer is triggered by changes to elements in the YArray.
+        Returns:
+            An identifier associated with the callback subscription.
+        """
+    def observe_deep(self, f: Callable[[List[Event]]]) -> SubscriptionId:
+        """
+        Assigns a callback function to listen to the aggregated updates of the YArray and its child elements.
+
+        Args:
+            f: Callback function that runs when the array object or components receive an update.
         Returns:
             An identifier associated with the callback subscription.
         """
@@ -642,15 +658,21 @@ class YMap:
             for (key, value) in map.items()):
                 print(key, value)
         """
-    def observe(
-        self, f: Callable[[Union[YMapEvent, List[Event]]]], deep: bool = False
-    ) -> SubscriptionId:
+    def observe(self, f: Callable[[YMapEvent]]) -> SubscriptionId:
         """
         Assigns a callback function to listen to YMap updates.
 
         Args:
             f: Callback function that runs when the map object receives an update.
-            deep: Determines whether observer is triggered by changes to elements in the YMap.
+        Returns:
+            A reference to the callback subscription. Delete this observer in order to erase the associated callback function.
+        """
+    def observe_deep(self, f: Callable[[List[Event]]]) -> SubscriptionId:
+        """
+        Assigns a callback function to listen to YMap and child element updates.
+
+        Args:
+            f: Callback function that runs when the map object or any of its tracked elements receive an update.
         Returns:
             A reference to the callback subscription. Delete this observer in order to erase the associated callback function.
         """
@@ -778,16 +800,23 @@ class YXmlElement:
         Returns an iterator that enables a deep traversal of this XML node - starting from first
         child over this XML node successors using depth-first strategy.
         """
-    def observe(
-        self, f: Callable[[Union[YXmlElementEvent, List[Event]]]], deep: bool = False
-    ) -> SubscriptionId:
+    def observe(self, f: Callable[[YXmlElementEvent]]) -> SubscriptionId:
         """
         Subscribes to all operations happening over this instance of `YXmlElement`. All changes are
         batched and eventually triggered during transaction commit phase.
 
         Args:
             f: A callback function that receives update events.
-            deep: Determines whether observer is triggered by changes to elements in the YXmlElement.
+        Returns:
+            A `SubscriptionId` that can be used to cancel the observer callback.
+        """
+    def observe_deep(self, f: Callable[[List[Event]]]) -> SubscriptionId:
+        """
+        Subscribes to all operations happening over this instance of `YXmlElement` and its children. All changes are
+        batched and eventually triggered during transaction commit phase.
+
+        Args:
+            f: A callback function that receives update events from the Xml element and its children.
         Returns:
             A `SubscriptionId` that can be used to cancel the observer callback.
         """
@@ -852,15 +881,24 @@ class YXmlText:
             An iterator that enables to traverse over all attributes of this XML node in
         unspecified order.
         """
-    def observe(
-        self, f: Callable[[Union[YXmlTextEvent, List[Event]]]], deep: bool = False
-    ) -> SubscriptionId:
+    def observe(self, f: Callable[[YXmlTextEvent]]) -> SubscriptionId:
         """
         Subscribes to all operations happening over this instance of `YXmlText`. All changes are
         batched and eventually triggered during transaction commit phase.
 
         Args:
             f: A callback function that receives update events.
+            deep: Determines whether observer is triggered by changes to elements in the YXmlText.
+        Returns:
+            A `SubscriptionId` that can be used to cancel the observer callback.
+        """
+    def observe_deep(self, f: Callable[[List[Event]]]) -> SubscriptionId:
+        """
+        Subscribes to all operations happening over this instance of `YXmlText` and its children. All changes are
+        batched and eventually triggered during transaction commit phase.
+
+        Args:
+            f: A callback function that receives update events of this element and its descendants.
             deep: Determines whether observer is triggered by changes to elements in the YXmlText.
         Returns:
             A `SubscriptionId` that can be used to cancel the observer callback.

--- a/y_py.pyi
+++ b/y_py.pyi
@@ -14,6 +14,8 @@ from typing import (
 
 SubscriptionId = int
 
+Event = Union[YTextEvent, YArrayEvent, YMapEvent, YXmlTextEvent, YXmlElementEvent]
+
 class YDoc:
     """
     A Ypy document type. Documents are most important units of collaborative resources management.
@@ -415,12 +417,15 @@ class YText:
         Deletes a specified range of of characters, starting at a given `index`.
         Both `index` and `length` are counted in terms of a number of UTF-8 character bytes.
         """
-    def observe(self, f: Callable[[YTextEvent]]) -> SubscriptionId:
+    def observe(
+        self, f: Callable[[Union[YTextEvent, List[Event]]]], deep: bool = False
+    ) -> SubscriptionId:
         """
         Assigns a callback function to listen to YText updates.
 
         Args:
             f: Callback function that runs when the text object receives an update.
+            deep: Determines whether the callback is triggered when embedded elements are changed.
         Returns:
             A reference to the callback subscription.
         """
@@ -518,12 +523,15 @@ class YArray:
             for item in array:
                 print(item)
         """
-    def observe(self, f: Callable[[YArrayEvent]]) -> SubscriptionId:
+    def observe(
+        self, f: Callable[[Union[YArrayEvent, List[Event]]]], deep: bool = False
+    ) -> SubscriptionId:
         """
         Assigns a callback function to listen to YArray updates.
 
         Args:
             f: Callback function that runs when the array object receives an update.
+            deep: Determines whether observer is triggered by changes to elements in the YArray.
         Returns:
             An identifier associated with the callback subscription.
         """
@@ -634,12 +642,15 @@ class YMap:
             for (key, value) in map.items()):
                 print(key, value)
         """
-    def observe(self, f: Callable[[YMapEvent]]) -> SubscriptionId:
+    def observe(
+        self, f: Callable[[Union[YMapEvent, List[Event]]]], deep: bool = False
+    ) -> SubscriptionId:
         """
         Assigns a callback function to listen to YMap updates.
 
         Args:
             f: Callback function that runs when the map object receives an update.
+            deep: Determines whether observer is triggered by changes to elements in the YMap.
         Returns:
             A reference to the callback subscription. Delete this observer in order to erase the associated callback function.
         """
@@ -767,13 +778,16 @@ class YXmlElement:
         Returns an iterator that enables a deep traversal of this XML node - starting from first
         child over this XML node successors using depth-first strategy.
         """
-    def observe(self, f: Callable[[YXmlElementEvent]]) -> SubscriptionId:
+    def observe(
+        self, f: Callable[[Union[YXmlElementEvent, List[Event]]]], deep: bool = False
+    ) -> SubscriptionId:
         """
         Subscribes to all operations happening over this instance of `YXmlElement`. All changes are
         batched and eventually triggered during transaction commit phase.
 
         Args:
             f: A callback function that receives update events.
+            deep: Determines whether observer is triggered by changes to elements in the YXmlElement.
         Returns:
             A `SubscriptionId` that can be used to cancel the observer callback.
         """
@@ -838,13 +852,16 @@ class YXmlText:
             An iterator that enables to traverse over all attributes of this XML node in
         unspecified order.
         """
-    def observe(self, f: Callable[[YXmlTextEvent]]) -> SubscriptionId:
+    def observe(
+        self, f: Callable[[Union[YXmlTextEvent, List[Event]]]], deep: bool = False
+    ) -> SubscriptionId:
         """
         Subscribes to all operations happening over this instance of `YXmlText`. All changes are
         batched and eventually triggered during transaction commit phase.
 
         Args:
             f: A callback function that receives update events.
+            deep: Determines whether observer is triggered by changes to elements in the YXmlText.
         Returns:
             A `SubscriptionId` that can be used to cancel the observer callback.
         """


### PR DESCRIPTION
Fixes #43 
Added deep observe option to all YTypes
## Example
```python
# will observe mutations directly on the `YArray` (old api)
sub = y_array.observe(fn)

# will recursively observe events inside the `YArray`
sub = y_array.observe(fn, deep=True)
```
## Updates
- [x] Added documentation and test cases.
- [x] Implemented deep observe for `YText`, `YMap`, `YArray`, `YXmlElement`, and `YXmlText`.
- [x] Fixed issue where deep observers will not unsubscribe.
- [ ] Tested `YText` deep observe with embedded objects (requires #21)