### PR TITLE
Updated YMap and YArray API

### DIFF
--- a/src/shared_types.rs
+++ b/src/shared_types.rs
@@ -13,6 +13,7 @@ use yrs::{types::TYPE_REFS_XML_ELEMENT, SubscriptionId};
 
 // Common errors
 create_exception!(y_py, PreliminaryObservationException, PyException, "Occurs when an observer is attached to a Y type that is not integrated into a YDoc. Y types can only be observed once they have been added to a YDoc.");
+create_exception!(y_py, IntegratedOperationException, PyException, "Occurs when a method requires a type to be integrated (embedded into a YDoc), but is called on a preliminary type.");
 
 /// Creates a default error with a common message string for throwing a `PyErr`.
 pub(crate) trait DefaultPyErr {
@@ -24,6 +25,14 @@ impl DefaultPyErr for PreliminaryObservationException {
     fn default_message() -> PyErr {
         PreliminaryObservationException::new_err(
             "Cannot observe a preliminary type. Must be added to a YDoc first",
+        )
+    }
+}
+
+impl DefaultPyErr for IntegratedOperationException {
+    fn default_message() -> PyErr {
+        IntegratedOperationException::new_err(
+            "This operation requires the type to be integrated into a YDoc.",
         )
     }
 }

--- a/src/shared_types.rs
+++ b/src/shared_types.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use pyo3::create_exception;
 use pyo3::{exceptions::PyException, prelude::*};
-use std::convert::TryFrom;
+use std::{convert::TryFrom, fmt::Display};
 use yrs::types::TYPE_REFS_XML_TEXT;
 use yrs::types::{TypeRefs, TYPE_REFS_ARRAY, TYPE_REFS_MAP, TYPE_REFS_TEXT};
 use yrs::{types::TYPE_REFS_XML_ELEMENT, SubscriptionId};
@@ -86,6 +86,19 @@ impl Shared {
             Shared::XmlElement(_) => TYPE_REFS_XML_ELEMENT,
             Shared::XmlText(_) => TYPE_REFS_XML_TEXT,
         }
+    }
+}
+
+impl Display for Shared {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let info = Python::with_gil(|py| match self {
+            Shared::Text(t) => t.borrow(py).__str__(),
+            Shared::Array(a) => a.borrow(py).__str__(),
+            Shared::Map(m) => m.borrow(py).__str__(),
+            Shared::XmlElement(xml) => xml.borrow(py).__str__(),
+            Shared::XmlText(xml) => xml.borrow(py).__str__(),
+        });
+        write!(f, "{}", info)
     }
 }
 

--- a/src/y_array.rs
+++ b/src/y_array.rs
@@ -108,7 +108,7 @@ impl YArray {
             SharedType::Prelim(vec) if vec.len() >= index as usize => {
                 Ok(vec.insert(index as usize, item))
             }
-            _ => Err(PyIndexError::new_err("Index out of bounds.")),
+            _ => Err(PyIndexError::default_message()),
         }
     }
 
@@ -133,7 +133,7 @@ impl YArray {
                 }
                 Ok(())
             }
-            _ => Err(PyIndexError::new_err("Index out of range.")),
+            _ => Err(PyIndexError::default_message()),
         }
     }
 
@@ -160,7 +160,7 @@ impl YArray {
                 v.remove(index as usize);
                 Ok(())
             }
-            _ => Err(PyIndexError::new_err("Index out of bounds.")),
+            _ => Err(PyIndexError::default_message()),
         }
     }
 
@@ -273,18 +273,14 @@ impl YArray {
                 if let Some(value) = v.get(index as u32) {
                     Ok(Python::with_gil(|py| value.into_py(py)))
                 } else {
-                    Err(PyIndexError::new_err(
-                        "Index outside the range of an YArray",
-                    ))
+                    Err(PyIndexError::default_message())
                 }
             }
             SharedType::Prelim(v) => {
                 if let Some(value) = v.get(index as usize) {
                     Ok(value.clone())
                 } else {
-                    Err(PyIndexError::new_err(
-                        "Index outside the range of an YArray",
-                    ))
+                    Err(PyIndexError::default_message())
                 }
             }
         }
@@ -507,5 +503,11 @@ impl YArrayEvent {
             self.delta = Some(delta.clone());
             delta
         }
+    }
+}
+
+impl DefaultPyErr for PyIndexError {
+    fn default_message() -> PyErr {
+        PyIndexError::new_err("Index out of bounds.")
     }
 }

--- a/src/y_map.rs
+++ b/src/y_map.rs
@@ -1,4 +1,4 @@
-use pyo3::exceptions::PyTypeError;
+use pyo3::exceptions::{PyKeyError, PyTypeError};
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use std::collections::HashMap;
@@ -141,36 +141,34 @@ impl YMap {
     }
 
     /// Removes an entry identified by a given `key` from this instance of `YMap`, if such exists.
-    pub fn delete(&mut self, txn: &mut YTransaction, key: &str) {
-        match &mut self.0 {
-            SharedType::Integrated(v) => {
-                v.remove(txn, key);
-            }
-            SharedType::Prelim(v) => {
-                v.remove(key);
-            }
-        }
+    pub fn pop(&mut self, txn: &mut YTransaction, key: &str) -> PyResult<PyObject> {
+        let popped = match &mut self.0 {
+            SharedType::Integrated(v) => v
+                .remove(txn, key)
+                .map(|v| Python::with_gil(|py| v.into_py(py))),
+            SharedType::Prelim(v) => v.remove(key),
+        };
+        popped.ok_or(PyKeyError::new_err(format!("{key}")))
+    }
+
+    /// Retrieves an item from the map. If the item isn't found, the fallback value is returned.
+    pub fn get(&self, key: &str, fallback: Option<PyObject>) -> PyObject {
+        self.__getitem__(key)
+            .ok()
+            .unwrap_or_else(|| fallback.unwrap_or_else(|| Python::with_gil(|py| py.None())))
     }
 
     /// Returns value of an entry stored under given `key` within this instance of `YMap`,
     /// or `undefined` if no such entry existed.
-    pub fn __getitem__(&self, key: &str) -> PyObject {
-        match &self.0 {
-            SharedType::Integrated(v) => Python::with_gil(|py| {
-                if let Some(value) = v.get(key) {
-                    value.into_py(py)
-                } else {
-                    py.None()
-                }
-            }),
-            SharedType::Prelim(v) => {
-                if let Some(value) = v.get(key) {
-                    value.clone()
-                } else {
-                    Python::with_gil(|py| py.None())
-                }
-            }
-        }
+    pub fn __getitem__(&self, key: &str) -> PyResult<PyObject> {
+        let entry = match &self.0 {
+            SharedType::Integrated(y_map) => y_map
+                .get(key)
+                .map(|value| Python::with_gil(|py| value.into_py(py))),
+            SharedType::Prelim(hash_map) => hash_map.get(key).map(|value| value.clone()),
+        };
+
+        entry.ok_or_else(|| PyKeyError::new_err(format!("{key}")))
     }
 
     /// Returns an iterator that can be used to traverse over all entries stored within this

--- a/tests/test_y_array.py
+++ b/tests/test_y_array.py
@@ -221,7 +221,7 @@ def test_deep_observe():
     container = ydoc.get_array("container")
     yarray = YArray([1, 2])
     with ydoc.begin_transaction() as txn:
-        container.push(txn, [yarray])
+        container.append(txn, yarray)
 
     events = None
 
@@ -231,7 +231,7 @@ def test_deep_observe():
 
     sub = container.observe_deep(callback)
     with ydoc.begin_transaction() as txn:
-        container[0].push(txn, [3])
+        container[0].append(txn, 3)
 
     assert events != None
 
@@ -239,6 +239,6 @@ def test_deep_observe():
     events = None
     container.unobserve(sub)
     with ydoc.begin_transaction() as txn:
-        container[0].push(txn, [4])
+        container[0].append(txn, 4)
 
     assert events == None

--- a/tests/test_y_doc.py
+++ b/tests/test_y_doc.py
@@ -35,7 +35,7 @@ def test_encoding():
     array = doc.get_array("test")
     contents = [True, 42, "string"]
     with doc.begin_transaction() as txn:
-        array.insert(txn, 0, contents)
+        array.insert_range(txn, 0, contents)
 
     state_vec = Y.encode_state_vector(receiver)
     update = Y.encode_state_as_update(doc, state_vec)
@@ -52,15 +52,14 @@ def test_boolean_encoding():
     doc = YDoc()
     receiver = YDoc()
     array = doc.get_array("test")
-    contents = [True]
     with doc.begin_transaction() as txn:
-        array.insert(txn, 0, contents)
+        array.insert(txn, 0, True)
 
     state_vec = Y.encode_state_vector(receiver)
     update = Y.encode_state_as_update(doc, state_vec)
     Y.apply_update(receiver, update)
     value = receiver.get_array("test").to_json()
-    assert type(value[0]) == type(contents[0])
+    assert type(value[0]) == type(True)
 
 
 def test_tutorial():

--- a/tests/test_y_map.py
+++ b/tests/test_y_map.py
@@ -95,6 +95,7 @@ def test_pop():
     with pytest.raises(KeyError):
         with d1.begin_transaction() as txn:
             x.pop(txn, "does not exist")
+        assert x.pop(txn, "does not exist", "fallback") == "fallback"
     length = len(x)
     value = x.get("key")
     assert length == 0

--- a/tests/test_y_map.py
+++ b/tests/test_y_map.py
@@ -3,11 +3,31 @@ import y_py as Y
 from y_py import YMap
 
 
+def test_get():
+    d = Y.YDoc()
+    m = d.get_map("map")
+
+    # Put user info into the map.
+    with d.begin_transaction() as txn:
+        m.update(txn, {"username": "John", "online": True})
+
+    # Extract the information from the map.
+    assert m.get("username") == "John"
+    assert m["online"] == True
+    # Ensure the default value is returned when key doesn't exist in map.
+    assert m.get("secretIdentity", "basic") == "basic"
+    # Ensure that nonexistant keys without default values return None.
+    assert m.get("SocialSecurityNumber") is None
+    # Ensure that indexing a non_existant key with bracket notation produces `KeyError`
+    with pytest.raises(KeyError):
+        m["doesn't exist"]
+
+
 def test_set():
     d1 = Y.YDoc()
     x = d1.get_map("test")
 
-    value = x["key"]
+    value = x.get("key")
     assert value == None
 
     d1.transact(lambda txn: x.set(txn, "key", "value1"))
@@ -61,7 +81,7 @@ def test_set_nested():
     assert json == {"key": {"a": "A", "b": "B"}}
 
 
-def test_delete():
+def test_pop():
     d1 = Y.YDoc()
     x = d1.get_map("test")
 
@@ -70,9 +90,13 @@ def test_delete():
     value = x["key"]
     assert length == 1
     assert value == "value1"
-    d1.transact(lambda txn: x.delete(txn, "key"))
+    d1.transact(lambda txn: x.pop(txn, "key"))
+
+    with pytest.raises(KeyError):
+        with d1.begin_transaction() as txn:
+            x.pop(txn, "does not exist")
     length = len(x)
-    value = x["key"]
+    value = x.get("key")
     assert length == 0
     assert value == None
 
@@ -136,7 +160,7 @@ def test_observer():
 
     # remove an entry and update another on
     with d1.begin_transaction() as txn:
-        x.delete(txn, "key1")
+        x.pop(txn, "key1")
         x.set(txn, "key2", "value2")
 
     assert get_value(target) == get_value(x)

--- a/tests/test_y_text.py
+++ b/tests/test_y_text.py
@@ -200,7 +200,6 @@ def test_formatting():
 def test_deep_observe():
     d = Y.YDoc()
     text = d.get_text("text")
-    nested = Y.YMap({"bold": True})
     with d.begin_transaction() as txn:
         text.push(txn, "Hello")
     events = None
@@ -222,6 +221,6 @@ def test_deep_observe():
     events = None
     text.unobserve(sub)
     with d.begin_transaction() as txn:
-        nested.delete(txn, "new_attr")
+        text.push(txn, " should not trigger")
 
     assert events is None

--- a/y_py.pyi
+++ b/y_py.pyi
@@ -501,15 +501,31 @@ class YArray:
         """
         Converts an underlying contents of this `YArray` instance into their JSON representation.
         """
-    def insert(self, txn: YTransaction, index: int, items: List[Any]):
+    def insert(self, txn: YTransaction, index: int, item: Any):
+        """
+        Inserts an item at the provided index in the `YArray`.
+        """
+    def insert_range(self, txn: YTransaction, index: int, items: Iterable):
         """
         Inserts a given range of `items` into this `YArray` instance, starting at given `index`.
         """
-    def push(self, txn: YTransaction, items: List[Any]):
+    def append(self, txn: YTransaction, item: Any):
         """
-        Appends a range of `items` at the end of this `YArray` instance.
+        Adds a single item to the end of the `YArray`
         """
-    def delete(self, txn: YTransaction, index: int, length: int):
+    def extend(self, txn: YTransaction, items: Iterable):
+        """
+        Appends a sequence of `items` at the end of this `YArray` instance.
+        """
+    def delete(self, txn: YTransaction, index: int):
+        """
+        Deletes a single item from the array
+
+        Args:
+            txn: The transaction where the array is being modified.
+            index: The index of the element to be deleted.
+        """
+    def delete_range(self, txn: YTransaction, index: int, length: int):
         """
         Deletes a range of items of given `length` from current `YArray` instance,
         starting from given `index`.
@@ -628,14 +644,34 @@ class YMap:
             txn: A transaction to perform the insertion updates.
             items: An iterable object that produces key value tuples to insert into the YMap
         """
-    def delete(self, txn: YTransaction, key: str):
+    def pop(self, txn: YTransaction, key: str) -> Any:
         """
         Removes an entry identified by a given `key` from this instance of `YMap`, if such exists.
-        """
-    def __getitem__(self, key: str) -> Any | None:
-        """
+        Throws a KeyError if the key does not exist.
+
+        Args:
+            txn: The current transaction from a YDoc.
+            key: Identifier of the requested item.
+
         Returns:
-            Value of an entry stored under given `key` within this instance of `YMap`, or `None` if no such entry existed.
+            The item at the key.
+        """
+    def get(key: str, fallback: Any) -> Any | None:
+        """
+        Args:
+            key: The identifier for the requested data.
+            fallback: If the key doesn't exist in the map, this fallback value will be returned.
+
+        Returns:
+            Requested data or the provided fallback value.
+        """
+    def __getitem__(self, key: str) -> Any:
+        """
+        Args:
+            key: The identifier for the requested data.
+
+        Returns:
+            Value of an entry stored under given `key` within this instance of `YMap`. Will throw a `KeyError` if the provided key is unassigned.
         """
     def __iter__(self) -> Iterator[str]:
         """

--- a/y_py.pyi
+++ b/y_py.pyi
@@ -644,14 +644,15 @@ class YMap:
             txn: A transaction to perform the insertion updates.
             items: An iterable object that produces key value tuples to insert into the YMap
         """
-    def pop(self, txn: YTransaction, key: str) -> Any:
+    def pop(self, txn: YTransaction, key: str, fallback: Optional[Any]) -> Any:
         """
         Removes an entry identified by a given `key` from this instance of `YMap`, if such exists.
-        Throws a KeyError if the key does not exist.
+        Throws a KeyError if the key does not exist and fallback value is not provided.
 
         Args:
             txn: The current transaction from a YDoc.
             key: Identifier of the requested item.
+            fallback: Returns this value if the key doesn't exist in the YMap
 
         Returns:
             The item at the key.


### PR DESCRIPTION
## API Updates
- YMap.delete -> YMap.pop: Reflects the dict api. Pop returns the removed value and throws a key error if it doesn't find a value.
- Added YMap.get: gets value from array with optional default value.
- YArray.delete -> YArray.delete_range
- YArray.insert -> YArray.insert_range: Now takes any iterable
- Added YArray.insert: Inserts a single element at index
- Added YArray.append: adds value to the end of the list
- Added YArray.delete: Deletes individual value

## Internel updates
- `py_into_any` refactored with more explicit error handling. Instead of returning `None` on error conditions, it now returns either a `MultipleIntegrationError` when attempting to integrate a non preliminary value and a `TypeError` when the supplied type cannot be integrated into YCRDT as `Any`. This centralizes the definition of errors and resolves issues in #46