### PR TITLE
YDoc Transaction Cleanup Hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ assert value == "hello world!"
 
 ## Development Setup
 
-0. Install Rust Nightly and Python
+0. Install Rust and Python
 1. Install `maturin` in order to build Ypy
 
 ```

--- a/src/y_doc.rs
+++ b/src/y_doc.rs
@@ -164,7 +164,7 @@ impl YDoc {
     }
 
     /// Subscribes a callback to a `YDoc` lifecycle event.
-    pub fn after_transaction_cleanup(&self, callback: PyObject) -> SubscriptionId {
+    pub fn after_transaction_cleanup(&mut self, callback: PyObject) -> SubscriptionId {
         self.0
             .on_transaction_cleanup(move |txn, event| {
                 Python::with_gil(|py| {
@@ -175,11 +175,6 @@ impl YDoc {
                 })
             })
             .into()
-    }
-
-    /// Cancels the callback associated with the `SubscriptionId`
-    pub fn unobserve(&mut self, subscription_id: SubscriptionId) -> PyResult<()> {
-        todo!("We need an `unobserve` method the yrs Doc")
     }
 }
 
@@ -254,13 +249,6 @@ pub fn encode_state_as_update(doc: &mut YDoc, vector: Option<Vec<u8>>) -> Vec<u8
 #[pyfunction]
 pub fn apply_update(doc: &mut YDoc, diff: Vec<u8>) {
     doc.begin_transaction().apply_v1(diff);
-}
-
-/// Possible hooks to for attaching callbacks to the `YDoc` via the `.on(hook, fn)` method.
-#[pyclass]
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub enum YDocHook {
-    TransactionCleanup,
 }
 
 #[pyclass(unsendable)]

--- a/src/y_doc.rs
+++ b/src/y_doc.rs
@@ -164,7 +164,7 @@ impl YDoc {
     }
 
     /// Subscribes a callback to a `YDoc` lifecycle event.
-    pub fn after_transaction_cleanup(&mut self, callback: PyObject) -> SubscriptionId {
+    pub fn observe_after_transaction(&mut self, callback: PyObject) -> SubscriptionId {
         self.0
             .on_transaction_cleanup(move |txn, event| {
                 Python::with_gil(|py| {

--- a/tests/test_y_doc.py
+++ b/tests/test_y_doc.py
@@ -99,21 +99,8 @@ def test_after_transaction_cleanup():
     # Update the document
     with doc.begin_transaction() as txn:
         text.insert(txn, 0, "abc")
-        text.remove_range(txn, 1, 2)
+        text.delete(txn, 1, 2)
 
     assert before_state != None
     assert after_state != None
     assert delete_set != None
-
-    # Test dropping the subscription
-    doc.unobserve(sub)
-    before_state = None
-    after_state = None
-    delete_set = None
-
-    with doc.begin_transaction() as txn:
-        text.insert(txn, 0, "should not update")
-
-    assert before_state == None
-    assert after_state == None
-    assert delete_set == None

--- a/tests/test_y_doc.py
+++ b/tests/test_y_doc.py
@@ -94,7 +94,7 @@ def test_after_transaction_cleanup():
         delete_set = event.delete_set
 
     # Subscribe callback
-    sub = doc.after_transaction_cleanup(callback)
+    sub = doc.observe_after_transaction(callback)
 
     # Update the document
     with doc.begin_transaction() as txn:

--- a/y_py.pyi
+++ b/y_py.pyi
@@ -127,10 +127,40 @@ class YDoc:
         If there was an instance with this name, but it was of different type, it will be projected
         onto `YText` instance.
         """
+    def after_transaction_cleanup(
+        self, callback: Callable[[AfterTransactionEvent]]
+    ) -> SubscriptionId:
+        """
+        Subscribe callback function to updates on the YDoc. The callback will receive encoded state updates and
+        deletions when a document transaction is committed.
 
-StateVector = List[int]
+        Args:
+            callback: A function that receives YDoc state information affected by the transaction.
 
-def encode_state_vector(doc: YDoc) -> StateVector:
+        Returns:
+            A subscription identifier that can be used to cancel the callback.
+        """
+    def unobserve(subscription: SubscriptionId):
+        """
+        Cancels subscriptions associated with a part of the YDoc lifecycle.
+
+        Args:
+            subscription: Subscription identifier for the callback to be cancelled.
+        """
+
+EncodedStateVector = List[int]
+EncodedDeleteSet = List[int]
+
+class AfterTransactionEvent:
+    """
+    Holds transaction update information from a commit after state vectors have been compressed.
+    """
+
+    before_state: EncodedStateVector
+    after_state: EncodedStateVector
+    delete_set: EncodedDeleteSet
+
+def encode_state_vector(doc: YDoc) -> EncodedStateVector:
     """
     Encodes a state vector of a given Ypy document into its binary representation using lib0 v1
     encoding. State vector is a compact representation of updates performed on a given document and
@@ -155,7 +185,9 @@ def encode_state_vector(doc: YDoc) -> StateVector:
 
 YDocUpdate = List[int]
 
-def encode_state_as_update(doc: YDoc, vector: Optional[StateVector]) -> YDocUpdate:
+def encode_state_as_update(
+    doc: YDoc, vector: Optional[EncodedStateVector]
+) -> YDocUpdate:
     """
     Encodes all updates that have happened since a given version `vector` into a compact delta
     representation using lib0 v1 encoding. If `vector` parameter has not been provided, generated

--- a/y_py.pyi
+++ b/y_py.pyi
@@ -127,7 +127,7 @@ class YDoc:
         If there was an instance with this name, but it was of different type, it will be projected
         onto `YText` instance.
         """
-    def after_transaction_cleanup(
+    def observe_after_transaction(
         self, callback: Callable[[AfterTransactionEvent]]
     ) -> SubscriptionId:
         """
@@ -475,6 +475,12 @@ class YText:
         """
 
 class YTextEvent:
+    """
+    Communicates updates that occurred during a transaction for an instance of `YText`.
+    The `target` references the `YText` element that receives the update.
+    The `delta` is a list of updates applied by the transaction.
+    """
+
     target: YText
     delta: List[YTextDelta]
     def path(self) -> List[Union[int, str]]:
@@ -605,6 +611,12 @@ class YArray:
 YArrayObserver = Any
 
 class YArrayEvent:
+    """
+    Communicates updates that occurred during a transaction for an instance of `YArray`.
+    The `target` references the `YArray` element that receives the update.
+    The `delta` is a list of updates applied by the transaction.
+    """
+
     target: YArray
     delta: List[ArrayDelta]
     def path(self) -> List[Union[int, str]]:
@@ -749,6 +761,13 @@ class YMap:
         """
 
 class YMapEvent:
+    """
+    Communicates updates that occurred during a transaction for an instance of `YMap`.
+    The `target` references the `YText` element that receives the update.
+    The `delta` is a list of updates applied by the transaction.
+    The `keys` are a list of changed values for a specific key.
+    """
+
     target: YMap
     delta: List[Dict]
     keys: List[YMapEventKeyChange]

--- a/y_py.pyi
+++ b/y_py.pyi
@@ -140,13 +140,6 @@ class YDoc:
         Returns:
             A subscription identifier that can be used to cancel the callback.
         """
-    def unobserve(subscription: SubscriptionId):
-        """
-        Cancels subscriptions associated with a part of the YDoc lifecycle.
-
-        Args:
-            subscription: Subscription identifier for the callback to be cancelled.
-        """
 
 EncodedStateVector = List[int]
 EncodedDeleteSet = List[int]


### PR DESCRIPTION
Adds the `after_transaction_cleanup` event
- Event exposes the encoded state vectors of a transaction
   - `before_state`
   - `after_state`
   - `delete_set`

This allows communication providers to subscribe to updates and send diffs to other users over the network.

**Note:** It is not currently possible to unsubscribe from this hook. Once there is a release of ycrdt with this pr, we'll add an `unobserve` method equivalent to `YDoc`.