### PR TITLE
Updated YText API

### DIFF
--- a/src/y_text.rs
+++ b/src/y_text.rs
@@ -171,16 +171,20 @@ impl YText {
     }
 
     /// Appends a given `chunk` of text at the end of current `YText` instance.
-    pub fn push(&mut self, txn: &mut YTransaction, chunk: &str) {
+    pub fn extend(&mut self, txn: &mut YTransaction, chunk: &str) {
         match &mut self.0 {
             SharedType::Integrated(v) => v.push(txn, chunk),
             SharedType::Prelim(v) => v.push_str(chunk),
         }
     }
+    /// Deletes character at the specified index.
+    pub fn delete(&mut self, txn: &mut YTransaction, index: u32) {
+        self.delete_range(txn, index, 1);
+    }
 
     /// Deletes a specified range of of characters, starting at a given `index`.
     /// Both `index` and `length` are counted in terms of a number of UTF-8 character bytes.
-    pub fn delete(&mut self, txn: &mut YTransaction, index: u32, length: u32) {
+    pub fn delete_range(&mut self, txn: &mut YTransaction, index: u32, length: u32) {
         match &mut self.0 {
             SharedType::Integrated(v) => v.remove_range(txn, index, length),
             SharedType::Prelim(v) => {

--- a/tests/test_y_doc.py
+++ b/tests/test_y_doc.py
@@ -66,7 +66,7 @@ def test_tutorial():
     d1 = Y.YDoc()
     text = d1.get_text("test")
     with d1.begin_transaction() as txn:
-        text.push(txn, "hello world!")
+        text.extend(txn, "hello world!")
 
     d2 = Y.YDoc()
     state_vector = Y.encode_state_vector(d2)
@@ -78,7 +78,7 @@ def test_tutorial():
     assert value == "hello world!"
 
 
-def test_after_transaction_cleanup():
+def test_observe_after_transaction():
     doc = Y.YDoc()
     text = doc.get_text("test")
     before_state = None
@@ -99,7 +99,7 @@ def test_after_transaction_cleanup():
     # Update the document
     with doc.begin_transaction() as txn:
         text.insert(txn, 0, "abc")
-        text.delete(txn, 1, 2)
+        text.delete_range(txn, 1, 2)
 
     assert before_state != None
     assert after_state != None

--- a/y_py.pyi
+++ b/y_py.pyi
@@ -437,11 +437,15 @@ class YText:
         formatting blocks containing provided `attributes` metadata. This method only works for
         `YText` instances that already have been integrated into document store
         """
-    def push(self, txn: YTransaction, chunk: str):
+    def extend(self, txn: YTransaction, chunk: str):
         """
         Appends a given `chunk` of text at the end of current `YText` instance.
         """
-    def delete(self, txn: YTransaction, index: int, length: int):
+    def delete(self, txn: YTransaction, index: int):
+        """
+        Deletes the character at the specified `index`.
+        """
+    def delete_range(self, txn: YTransaction, index: int, length: int):
         """
         Deletes a specified range of of characters, starting at a given `index`.
         Both `index` and `length` are counted in terms of a number of UTF-8 character bytes.


### PR DESCRIPTION
- `.push()` -> `.extend()`
- `.delete()` -> `.delete_range()`
- `delete(self,txn, index)` deletes a single character