### PR TITLE
Added `before_state` as a `YTransaction` property

### DIFF
--- a/src/y_doc.rs
+++ b/src/y_doc.rs
@@ -97,7 +97,7 @@ impl YDoc {
     ///     text.insert(txn, 0, 'hello world')
     /// ```
     pub fn begin_transaction(&mut self) -> YTransaction {
-        YTransaction(self.0.transact())
+        YTransaction::new(self.0.transact())
     }
 
     pub fn transact(&mut self, callback: PyObject) -> PyResult<PyObject> {

--- a/tests/test_y_transaction.py
+++ b/tests/test_y_transaction.py
@@ -1,0 +1,12 @@
+import y_py as Y
+
+def test_before_state():
+    doc = Y.YDoc()
+    text = doc.get_text("test")
+    with doc.begin_transaction() as txn:
+        text.extend(txn, "Hello")
+        assert txn.before_state == {}
+    with doc.begin_transaction() as txn:
+        text.extend(txn, " World")
+        assert len(txn.before_state) == 1
+    

--- a/y_py.pyi
+++ b/y_py.pyi
@@ -240,6 +240,8 @@ class YTransaction:
             text.insert(txn, 0, 'hello world')
     """
 
+    before_state: Dict[int, int]
+
     def get_text(self, name: str) -> YText:
         """
         Returns:


### PR DESCRIPTION
Fixes #40
- Before state is cached on the YTransaction object as a dictionary map between client Id and pointer. Requires iterating through internal representation of before state, so the result is cached in case it is referenced multiple times.
- Added basic tests