### PR TITLE
YMap Items View

### DIFF
--- a/src/y_map.rs
+++ b/src/y_map.rs
@@ -182,7 +182,7 @@ impl YMap {
         entry.ok_or_else(|| PyKeyError::new_err(format!("{key}")))
     }
 
-    /// Returns an iterator that can be used to traverse over all entries stored within this
+    /// Returns an item view that can be used to traverse over all entries stored within this
     /// instance of `YMap`. Order of entry is not specified.
     ///
     /// Example:
@@ -199,23 +199,13 @@ impl YMap {
     ///     for (key, value) in map.entries(txn)):
     ///         print(key, value)
     /// ```
-    pub fn items(&self) -> YMapIterator {
-        match &self.0 {
-            SharedType::Integrated(val) => unsafe {
-                let this: *const Map = val;
-                let shared_iter = InnerYMapIterator::Integrated((*this).iter());
-                YMapIterator(ManuallyDrop::new(shared_iter))
-            },
-            SharedType::Prelim(val) => unsafe {
-                let this: *const HashMap<String, PyObject> = val;
-                let shared_iter = InnerYMapIterator::Prelim((*this).iter());
-                YMapIterator(ManuallyDrop::new(shared_iter))
-            },
-        }
+    pub fn items(&self) -> ItemView {
+        ItemView(&self.0)
     }
 
     pub fn __iter__(&self) -> YMapKeyIterator {
-        YMapKeyIterator(self.items())
+        let inner: *const _ = &self.0;
+        YMapKeyIterator(YMapIterator::from(inner))
     }
 
     pub fn observe(&mut self, f: PyObject) -> PyResult<ShallowSubscription> {
@@ -267,6 +257,55 @@ impl YMap {
     }
 }
 
+#[pyclass(unsendable)]
+pub struct ItemView(*const SharedType<Map, HashMap<String, PyObject>>);
+
+#[pymethods]
+impl ItemView {
+    fn __iter__(slf: PyRef<Self>) -> YMapIterator {
+        YMapIterator::from(slf.0)
+    }
+
+    fn __len__(&self) -> usize {
+        unsafe {
+            match &*self.0 {
+                SharedType::Integrated(map) => map.len() as usize,
+                SharedType::Prelim(map) => map.len(),
+            }
+        }
+    }
+
+    fn __str__(&self) -> String {
+        let vals: String = YMapIterator::from(self.0)
+            .map(|(key, val)| format!("({key}, {val})"))
+            .collect::<Vec<String>>()
+            .join(", ");
+        format!("{{{vals}}}")
+    }
+
+    fn __repr__(&self) -> String {
+        let data = self.__str__();
+        format!("ItemView({data})")
+    }
+
+    fn __contains__(&self, el: PyObject) -> bool {
+        let kv: Result<(String, PyObject), _> = Python::with_gil(|py| el.extract(py));
+        kv.ok()
+            .and_then(|(key, value)| unsafe {
+                match &*self.0 {
+                    SharedType::Integrated(map) if map.contains(&key) => map.get(&key).map(|v| {
+                        Python::with_gil(|py| v.into_py(py).as_ref(py).eq(value)).unwrap_or(false)
+                    }),
+                    SharedType::Prelim(map) if map.contains_key(&key) => map
+                        .get(&key)
+                        .map(|v| Python::with_gil(|py| v.as_ref(py).eq(value).unwrap_or(false))),
+                    _ => None,
+                }
+            })
+            .unwrap_or(false)
+    }
+}
+
 pub enum InnerYMapIterator {
     Integrated(MapIter<'static>),
     Prelim(std::collections::hash_map::Iter<'static, String, PyObject>),
@@ -278,6 +317,25 @@ pub struct YMapIterator(ManuallyDrop<InnerYMapIterator>);
 impl Drop for YMapIterator {
     fn drop(&mut self) {
         unsafe { ManuallyDrop::drop(&mut self.0) }
+    }
+}
+
+impl From<*const SharedType<Map, HashMap<String, PyObject>>> for YMapIterator {
+    fn from(inner_map_ptr: *const SharedType<Map, HashMap<String, PyObject>>) -> Self {
+        unsafe {
+            match &*inner_map_ptr {
+                SharedType::Integrated(val) => {
+                    let this: *const Map = val;
+                    let shared_iter = InnerYMapIterator::Integrated((*this).iter());
+                    YMapIterator(ManuallyDrop::new(shared_iter))
+                }
+                SharedType::Prelim(val) => {
+                    let this: *const HashMap<String, PyObject> = val;
+                    let shared_iter = InnerYMapIterator::Prelim((*this).iter());
+                    YMapIterator(ManuallyDrop::new(shared_iter))
+                }
+            }
+        }
     }
 }
 

--- a/tests/test_y_map.py
+++ b/tests/test_y_map.py
@@ -133,10 +133,44 @@ def test_items_view():
         m.set(txn, "d", 4)
         assert ("d", 4) in items
 
-        expected = list("abcd")
-        for key in m:
-            assert key in expected
-            assert key in m
+
+def test_keys_values():
+    d = Y.YDoc()
+    m = d.get_map("test")
+    expected_keys = list("abc")
+    expected_values = list(range(1, 4))
+    with d.begin_transaction() as txn:
+        m.update(txn, zip(expected_keys, expected_values))
+
+    # Ensure basic iteration works
+    for key in m:
+        assert key in expected_keys
+        assert key in m
+
+    # Ensure keys can be iterated over multiple times
+    keys = m.keys()
+    for _ in range(2):
+        for key in keys:
+            assert key in expected_keys
+            assert key in keys
+
+    values = m.values()
+
+    for _ in range(2):
+        for val in values:
+            assert val in expected_values
+            assert val in values
+
+    # Ensure keys and values reflect updates to map
+    with d.begin_transaction() as txn:
+        m.set(txn, "d", 4)
+
+    assert "d" in keys
+    assert 4 in values
+
+    # Ensure key view operations
+    assert len(keys) == 4
+    assert len(values) == 4
 
 
 def test_observer():

--- a/y_py.pyi
+++ b/y_py.pyi
@@ -736,7 +736,7 @@ class YMap:
     def items(self) -> YMapItemsView:
         """
         Returns:
-            An iterator that can be used to traverse over all entries stored within this instance of `YMap`. Order of entry is not specified.
+            A view that can be used to iterate over all entries stored within this instance of `YMap`. Order of entry is not specified.
 
         Example::
 
@@ -750,6 +750,16 @@ class YMap:
                 map.set(txn, 'key2', true)
             for (key, value) in map.items()):
                 print(key, value)
+        """
+    def keys(self) -> YMapKeysView:
+        """
+        Returns:
+            A view of all key identifiers in the YMap. The order of keys is not stable.
+        """
+    def values(self) -> YMapValuesView:
+        """
+        Returns:
+            A view of all values in the YMap. The order of values is not stable.
         """
     def observe(self, f: Callable[[YMapEvent]]) -> SubscriptionId:
         """
@@ -781,11 +791,31 @@ class YMapItemsView:
     """Tracks key/values inside a YMap. Similar functionality to dict_items for a Python dict"""
 
     def __iter__() -> Iterator[Tuple[str, Any]]:
-        """Produces key value tuples of elements inside the map"""
+        """Produces key value tuples of elements inside the view"""
     def __contains__() -> bool:
         """Checks membership of kv tuples in the view"""
     def __len__() -> int:
         """Checks number of items in the view."""
+
+class YMapKeysView:
+    """Tracks key identifiers inside of a YMap"""
+
+    def __iter__() -> Iterator[str]:
+        """Produces keys of the view"""
+    def __contains__() -> bool:
+        """Checks membership of keys in the view"""
+    def __len__() -> int:
+        """Checks number of keys in the view."""
+
+class YMapValuesView:
+    """Tracks values inside of a YMap"""
+
+    def __iter__() -> Iterator[Any]:
+        """Produces values of the view"""
+    def __contains__() -> bool:
+        """Checks membership of values in the view"""
+    def __len__() -> int:
+        """Checks number of values in the view."""
 
 class YMapEvent:
     """

--- a/y_py.pyi
+++ b/y_py.pyi
@@ -45,9 +45,9 @@ class YDoc:
     client_id: int
     def __init__(
         self,
-        client_id: Optional[int]=None,
-        offset_kind: str="utf8",
-        skip_gc:bool=False,
+        client_id: Optional[int] = None,
+        offset_kind: str = "utf8",
+        skip_gc: bool = False,
     ):
         """
         Creates a new Ypy document. If `client_id` parameter was passed it will be used as this
@@ -145,7 +145,6 @@ EncodedStateVector = bytes
 EncodedDeleteSet = bytes
 YDocUpdate = bytes
 
-
 class AfterTransactionEvent:
     """
     Holds transaction update information from a commit after state vectors have been compressed.
@@ -178,9 +177,8 @@ def encode_state_vector(doc: YDoc) -> EncodedStateVector:
 
     """
 
-
 def encode_state_as_update(
-    doc: YDoc, vector: Optional[Union[EncodedStateVector, List[int]]]=None
+    doc: YDoc, vector: Optional[Union[EncodedStateVector, List[int]]] = None
 ) -> YDocUpdate:
     """
     Encodes all updates that have happened since a given version `vector` into a compact delta
@@ -307,7 +305,7 @@ class YTransaction:
                 del remote_txn
 
         """
-    def diff_v1(self, vector: Optional[EncodedStateVector]=None) -> YDocUpdate:
+    def diff_v1(self, vector: Optional[EncodedStateVector] = None) -> YDocUpdate:
         """
         Encodes all updates that have happened since a given version `vector` into a compact delta
         representation using lib0 v1 encoding. If `vector` parameter has not been provided, generated
@@ -382,7 +380,7 @@ class YText:
     prelim: bool
     """True if this element has not been integrated into a YDoc."""
 
-    def __init__(self, init:str=""):
+    def __init__(self, init: str = ""):
         """
         Creates a new preliminary instance of a `YText` shared data type, with its state initialized
         to provided parameter.
@@ -416,7 +414,7 @@ class YText:
         txn: YTransaction,
         index: int,
         chunk: str,
-        attributes: Dict[str, Any]={},
+        attributes: Dict[str, Any] = {},
     ):
         """
         Inserts a string of text into the `YText` instance starting at a given `index`.
@@ -428,7 +426,7 @@ class YText:
         txn: YTransaction,
         index: int,
         embed: Any,
-        attributes: Dict[str, Any]={},
+        attributes: Dict[str, Any] = {},
     ):
         """
         Inserts embedded content into the YText at the provided index. Attributes are user-defined metadata associated with the embedded content.
@@ -515,7 +513,7 @@ class YArray:
     prelim: bool
     """True if this element has not been integrated into a YDoc."""
 
-    def __init__(init: Optional[Iterable[Any]]=None):
+    def __init__(init: Optional[Iterable[Any]] = None):
         """
         Creates a new preliminary instance of a `YArray` shared data type, with its state
         initialized to provided parameter.
@@ -641,14 +639,17 @@ ArrayDelta = Union[ArrayChangeInsert, ArrayChangeDelete, ArrayChangeRetain]
 
 class ArrayChangeInsert(TypedDict):
     """Update message that elements were inserted in a YArray."""
+
     insert: List[Any]
 
 class ArrayChangeDelete:
     """Update message that elements were deleted in a YArray."""
+
     delete: int
 
 class ArrayChangeRetain:
     """Update message that elements were left unmodified in a YArray."""
+
     retain: int
 
 class YMap:
@@ -697,7 +698,7 @@ class YMap:
             txn: A transaction to perform the insertion updates.
             items: An iterable object that produces key value tuples to insert into the YMap
         """
-    def pop(self, txn: YTransaction, key: str, fallback: Optional[Any]=None) -> Any:
+    def pop(self, txn: YTransaction, key: str, fallback: Optional[Any] = None) -> Any:
         """
         Removes an entry identified by a given `key` from this instance of `YMap`, if such exists.
         Throws a KeyError if the key does not exist and fallback value is not provided.
@@ -732,7 +733,7 @@ class YMap:
         Returns:
             An iterator that traverses all keys of the `YMap` in an unspecified order.
         """
-    def items(self) -> Iterator[Tuple[str, Any]]:
+    def items(self) -> YMapItemsView:
         """
         Returns:
             An iterator that can be used to traverse over all entries stored within this instance of `YMap`. Order of entry is not specified.
@@ -775,6 +776,16 @@ class YMap:
         Args:
             subscription_id: reference to a subscription provided by the `observe` method.
         """
+
+class YMapItemsView:
+    """Tracks key/values inside a YMap. Similar functionality to dict_items for a Python dict"""
+
+    def __iter__() -> Iterator[Tuple[str, Any]]:
+        """Produces key value tuples of elements inside the map"""
+    def __contains__() -> bool:
+        """Checks membership of kv tuples in the view"""
+    def __len__() -> int:
+        """Checks number of items in the view."""
 
 class YMapEvent:
     """


### PR DESCRIPTION
Fixes #58
To more closely mirror the functionality of dict.items(), YMap.items() now returns an ItemsView:
- Stays up to date with changes in the YMap
- Supports length and membership checks in constant time
- Supports multiple iterations, instead of getting exhausted like a standard iterator.