### PR TITLE
After Transaction Update

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ pub fn y_py(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<y_map::YMapEvent>()?;
     m.add_class::<y_xml::YXmlTextEvent>()?;
     m.add_class::<y_xml::YXmlEvent>()?;
+    m.add_class::<y_doc::AfterTransactionEvent>()?;
     // Functions
     m.add_wrapped(wrap_pyfunction!(encode_state_vector))?;
     m.add_wrapped(wrap_pyfunction!(encode_state_as_update))?;

--- a/src/type_conversions.rs
+++ b/src/type_conversions.rs
@@ -30,10 +30,7 @@ pub trait ToPython {
     fn into_py(self, py: Python) -> PyObject;
 }
 
-impl<T> ToPython for Vec<T>
-where
-    T: ToPython,
-{
+impl ToPython for Vec<Any> {
     fn into_py(self, py: Python) -> PyObject {
         let elements = self.into_iter().map(|v| v.into_py(py));
         let arr: PyObject = pyo3::types::PyList::new(py, elements).into();

--- a/src/y_transaction.rs
+++ b/src/y_transaction.rs
@@ -261,6 +261,6 @@ impl YTransaction {
     ) -> PyResult<bool> {
         self.commit();
         drop(self);
-        Ok(exception_type.map_or(true, |_| false))
+        Ok(exception_type.is_none())
     }
 }

--- a/tests/test_y_doc.py
+++ b/tests/test_y_doc.py
@@ -1,4 +1,5 @@
-from y_py import YDoc
+from y_py import YDoc, AfterTransactionEvent
+
 import y_py as Y
 import pytest
 
@@ -104,3 +105,24 @@ def test_observe_after_transaction():
     assert before_state != None
     assert after_state != None
     assert delete_set != None
+
+
+def test_get_update():
+    """
+    Ensures that developers can access the encoded update data in the `observe_after_transaction` event.
+    """
+    d = Y.YDoc()
+    m = d.get_map("foo")
+    r = d.get_map("foo")
+    update: bytes = None
+
+    def get_update(event: AfterTransactionEvent) -> None:
+        nonlocal update
+        update = event.get_update()
+
+    d.observe_after_transaction(get_update)
+
+    with d.begin_transaction() as txn:
+        m.set(txn, "hi", "there")
+
+    assert type(update) == bytes

--- a/y_py.pyi
+++ b/y_py.pyi
@@ -151,8 +151,23 @@ class AfterTransactionEvent:
     """
 
     before_state: EncodedStateVector
+    """
+    Encoded state of YDoc before the transaction.
+    """
     after_state: EncodedStateVector
+    """
+    Encoded state of the YDoc after the transaction.
+    """
     delete_set: EncodedDeleteSet
+    """
+    Elements deleted by the associated transaction.
+    """
+
+    def get_update(self) -> YDocUpdate:
+        """
+        Returns:
+            Encoded payload of all updates produced by the transaction.
+        """
 
 def encode_state_vector(doc: YDoc) -> EncodedStateVector:
     """


### PR DESCRIPTION
Adds the `get_update` method to the AfterTransactionEvent so that delta state is accessible in the `observe_after_transaction` callback.

Fixes #69 

- Updated some YDoc methods to not require mutable access.
- Exposed AfterTransactionEvent to library users.
- Reduced blanket `ToPython` array impl to just handle Vec<Any>
- Added test to verify `get_update`