### PR TITLE
Wrapper Refactor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["maturin>=0.13"]
+requires = ["maturin>=0.13,<0.14"]
 build-backend = "maturin"

--- a/src/shared_types.rs
+++ b/src/shared_types.rs
@@ -1,12 +1,14 @@
 use crate::{
+    type_conversions::{py_into_any, MultipleIntegrationError},
     y_array::YArray,
     y_map::YMap,
     y_text::YText,
     y_xml::{YXmlElement, YXmlText},
 };
+use lib0::any::Any;
 use pyo3::create_exception;
 use pyo3::{exceptions::PyException, prelude::*};
-use std::{convert::TryFrom, fmt::Display};
+use std::{collections::HashMap, convert::TryFrom, fmt::Display};
 use yrs::types::TYPE_REFS_XML_TEXT;
 use yrs::types::{TypeRefs, TYPE_REFS_ARRAY, TYPE_REFS_MAP, TYPE_REFS_TEXT};
 use yrs::{types::TYPE_REFS_XML_ELEMENT, SubscriptionId};
@@ -130,5 +132,46 @@ impl TryFrom<PyObject> for Shared {
                 ))
             }
         })
+    }
+}
+
+impl TryFrom<Shared> for Any {
+    type Error = PyErr;
+
+    fn try_from(shared: Shared) -> Result<Self, Self::Error> {
+        const integrated_message: &str = "All shared types should be preliminary at this point.";
+
+        if shared.is_prelim() {
+            Python::with_gil(|py| match shared {
+                Shared::Text(text) => match text.borrow(py).0 {
+                    SharedType::Prelim(text) => Ok(Any::String(text.into_boxed_str())),
+                    SharedType::Integrated(_) => unreachable!(integrated_message),
+                },
+                Shared::Array(array) => match array.borrow(py).0 {
+                    SharedType::Prelim(array) => {
+                        let any_array: PyResult<Vec<Any>> =
+                            array.into_iter().map(|v| py_into_any(v)).collect();
+                        Ok(Any::Array(any_array?.into_boxed_slice()))
+                    }
+                    SharedType::Integrated(_) => unreachable!(integrated_message),
+                },
+                Shared::Map(dict) => match dict.borrow(py).0 {
+                    SharedType::Prelim(dict) => {
+                        let any_dict: PyResult<HashMap<String, Any>> = dict
+                            .into_iter()
+                            .map(|(k, v)| py_into_any(v).map(|v| (k, v)))
+                            .collect();
+                        Ok(Any::Map(Box::new(any_dict?)))
+                    }
+                    SharedType::Integrated(_) => unreachable!(integrated_message),
+                },
+                Shared::XmlElement(xml) => unimplemented!(),
+                Shared::XmlText(xml) => unimplemented!(),
+            })
+        } else {
+            Err(MultipleIntegrationError::new_err(format!(
+                "Cannot integrate a nested Ypy object because is already integrated into a YDoc: {shared}"
+            )))
+        }
     }
 }

--- a/src/type_conversions.rs
+++ b/src/type_conversions.rs
@@ -114,6 +114,7 @@ impl ToPython for &Change {
     }
 }
 
+#[repr(transparent)]
 struct EntryChangeWrapper<'a>(&'a EntryChange);
 
 impl<'a> IntoPy<PyObject> for EntryChangeWrapper<'a> {
@@ -143,6 +144,7 @@ impl<'a> IntoPy<PyObject> for EntryChangeWrapper<'a> {
     }
 }
 
+#[repr(transparent)]
 pub(crate) struct PyObjectWrapper(pub PyObject);
 
 impl Prelim for PyObjectWrapper {
@@ -258,7 +260,9 @@ impl TryFrom<PyObjectWrapper> for Any {
                     .collect();
                 result.map(|res| Any::Map(Box::new(res)))
             } else if let Ok(v) = Shared::try_from(PyObject::from(v)) {
-                v.try_into()
+                Err(MultipleIntegrationError::new_err(format!(
+                    "Cannot integrate a nested Ypy object because is already integrated into a YDoc: {v}"
+                )))
             } else {
                 Err(PyTypeError::new_err(format!(
                     "Cannot integrate this type into a YDoc: {v}"

--- a/src/y_map.rs
+++ b/src/y_map.rs
@@ -12,7 +12,7 @@ use crate::shared_types::{
     DeepSubscription, DefaultPyErr, PreliminaryObservationException, ShallowSubscription,
     SharedType, SubId,
 };
-use crate::type_conversions::{events_into_py, PyValueWrapper, ToPython};
+use crate::type_conversions::{events_into_py, PyObjectWrapper, ToPython};
 use crate::y_transaction::YTransaction;
 
 /// Collection used to store key-value entries in an unordered manner. Keys are always represented
@@ -103,7 +103,7 @@ impl YMap {
     pub fn set(&mut self, txn: &mut YTransaction, key: &str, value: PyObject) {
         match &mut self.0 {
             SharedType::Integrated(v) => {
-                v.insert(txn, key.to_string(), PyValueWrapper(value));
+                v.insert(txn, key.to_string(), PyObjectWrapper(value));
             }
             SharedType::Prelim(v) => {
                 v.insert(key.to_string(), value);

--- a/src/y_text.rs
+++ b/src/y_text.rs
@@ -2,13 +2,13 @@ use crate::shared_types::{
     DeepSubscription, DefaultPyErr, IntegratedOperationException, PreliminaryObservationException,
     ShallowSubscription, SharedType, SubId,
 };
-use crate::type_conversions::py_into_any;
-use crate::type_conversions::{events_into_py, ToPython};
+use crate::type_conversions::{events_into_py, PyObjectWrapper, ToPython};
 use crate::y_transaction::YTransaction;
 use lib0::any::Any;
 use pyo3::prelude::*;
 use pyo3::types::PyList;
 use std::collections::HashMap;
+use std::convert::TryInto;
 use std::rc::Rc;
 use yrs::types::text::TextEvent;
 use yrs::types::Attrs;
@@ -136,7 +136,7 @@ impl YText {
     ) -> PyResult<()> {
         match &mut self.0 {
             SharedType::Integrated(text) => {
-                let content = py_into_any(embed)?;
+                let content = PyObjectWrapper(embed).try_into()?;
                 if let Some(Ok(attrs)) = attributes.map(Self::parse_attrs) {
                     text.insert_embed_with_attributes(txn, index, content, attrs)
                 } else {
@@ -250,7 +250,7 @@ impl YText {
             .into_iter()
             .map(|(k, v)| {
                 let key = Rc::from(k);
-                let value = py_into_any(v)?;
+                let value = PyObjectWrapper(v).try_into()?;
                 Ok((key, value))
             })
             .collect()

--- a/tests/test_y_map.py
+++ b/tests/test_y_map.py
@@ -258,10 +258,8 @@ def test_deep_observe():
 
 def test_borrow_issue():
     doc = Y.YDoc()
-    wrapper = doc.get_map("wrapper")
+    wrapper = doc.get_array("wrapper")
     inner = Y.YMap({"Foo": "Bar"})
 
     with doc.begin_transaction() as txn:
-        wrapper.set(txn, "inner", inner)
-
-    print(wrapper)
+        wrapper.append(txn, inner)

--- a/tests/test_y_map.py
+++ b/tests/test_y_map.py
@@ -254,3 +254,14 @@ def test_deep_observe():
         container["inner"].set(txn, "don't show up", 1)
 
     assert events is None
+
+
+def test_borrow_issue():
+    doc = Y.YDoc()
+    wrapper = doc.get_map("wrapper")
+    inner = Y.YMap({"Foo": "Bar"})
+
+    with doc.begin_transaction() as txn:
+        wrapper.set(txn, "inner", inner)
+
+    print(wrapper)


### PR DESCRIPTION
Minor refactor of the codebase:
- Moved the `py_into_any` function into the `PyObjectWrapper` class as a `try_from` trait operation. This centralizes the type conversions to a single type, but could also make the code slightly less readable.
- Deleted `PyValueWrapper` which was identical to `PyObjectWrapper` and just acted as bloat.
- Updated wrapper types to use `#[repr(transparent)]`. This should more aggressively optimize away the wrapper types.
- Added upper version bound to `maturin` so it won't break our distribution system by surprise again.