### PR TITLE
More Poetry support, move some metadata to pyproject.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,7 @@
 name = "y-py"
 version = "0.5.4"
 rust-version = "1.58"
-authors = ["John Waidhofer <waidhoferj@gmail.com>", "Kevin Jahns <kevin.jahns@protonmail.com>", "Pierre-Olivier Simonard <pierre.olivier.simonard@gmail.com>"]
 edition = "2018"
-homepage = "https://github.com/y-crdt/ypy"
-repository = "https://github.com/y-crdt/ypy"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -39,28 +39,29 @@ assert value == "hello world!"
 
 ## Development Setup
 
-0. Install Rust and Python
-1. Install `maturin` in order to build Ypy
+0. [Install Rust](https://www.rust-lang.org/tools/install) and [Python](https://www.python.org/downloads/) (consider [pyenv](https://github.com/pyenv/pyenv))
+1. [Install Poetry](https://python-poetry.org/docs/#installation) 
+ - [Optional] Configure Poetry to create `.venv` folders in current directory when running `poetry install`: `poetry config virtualenvs.in-project true`
+2. Install the `y-py` dependencies into the virtual environment and build a wheel for `y-py` using `maturin`
 
+*All `poetry run` commands below can be replaced by entering into `poetry shell` first if you prefer*
 ```
-pip install maturin
+poetry install
+poetry run maturin develop
 ```
-
-2. Create a development build of the library
-   `maturin develop`
 
 ## Tests
 
-All tests are located in `/tests`. You can run them with `pytest`.
+All tests are located in `/tests`. You can run them with:
 
 ```
-pytest
+poetry run pytest
 ```
 
 ## Build Ypy :
 
-Build the library as a wheel and store them in `target/wheels` :
+Build the library as a wheel and store them in `target/wheels`:
 
 ```
-maturin build
+poetry run maturin build
 ```

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,0 +1,134 @@
+[[package]]
+name = "attrs"
+version = "22.1.0"
+description = "Classes Without Boilerplate"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[package.extras]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
+docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "cloudpickle"]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+description = "Cross-platform colored terminal text."
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
+
+[[package]]
+name = "exceptiongroup"
+version = "1.0.0"
+description = "Backport of PEP 654 (exception groups)"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+test = ["pytest (>=6)"]
+
+[[package]]
+name = "iniconfig"
+version = "1.1.1"
+description = "iniconfig: brain-dead simple config-ini parsing"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "maturin"
+version = "0.13.7"
+description = "Build and publish crates with pyo3, rust-cpython and cffi bindings as well as rust binaries as python packages"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+
+[package.extras]
+zig = ["ziglang (>=0.9.0,<0.10.0)"]
+patchelf = ["patchelf"]
+
+[[package]]
+name = "packaging"
+version = "21.3"
+description = "Core utilities for Python packages"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
+
+[[package]]
+name = "pluggy"
+version = "1.0.0"
+description = "plugin and hook calling mechanisms for python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+testing = ["pytest-benchmark", "pytest"]
+dev = ["tox", "pre-commit"]
+
+[[package]]
+name = "pyparsing"
+version = "3.0.9"
+description = "pyparsing module - Classes and methods to define and execute parsing grammars"
+category = "dev"
+optional = false
+python-versions = ">=3.6.8"
+
+[package.extras]
+diagrams = ["railroad-diagrams", "jinja2"]
+
+[[package]]
+name = "pytest"
+version = "7.2.0"
+description = "pytest: simple powerful testing with Python"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+attrs = ">=19.2.0"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=0.12,<2.0"
+tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
+
+[package.extras]
+testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
+
+[[package]]
+name = "tomli"
+version = "2.0.1"
+description = "A lil' TOML parser"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.9"
+content-hash = "c919c29c7c2a9dee0fc48ce7bd1b5d25ed83e6bfa7b93a37004fd65a33021d5e"
+
+[metadata.files]
+attrs = []
+colorama = []
+exceptiongroup = []
+iniconfig = []
+maturin = []
+packaging = []
+pluggy = []
+pyparsing = []
+pytest = []
+tomli = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,16 @@ version = "0.5.4"
 description = "Python bindings for the Y-CRDT built from yrs (Rust)"
 authors = ["John Waidhofer <waidhoferj@gmail.com>", "Kevin Jahns <kevin.jahns@protonmail.com>", "Pierre-Olivier Simonard <pierre.olivier.simonard@gmail.com>"]
 license = "MIT"
+homepage = "https://github.com/y-crdt/ypy"
+repository = "https://github.com/y-crdt/ypy"
 
 [tool.poetry.dependencies]
 python = "^3.9"
 
+# May get a deprecation warning developing with Poetry >=1.2, but at least
+# using .dev-dependencies vice .group.dev.dependencies won't throw an error if 
+# you're using Poetry <1.2
+# https://python-poetry.org/blog/announcing-poetry-1.2.0/#dependency-groups
 [tool.poetry.dev-dependencies]
 pytest = "^7.2.0"
 maturin = "^0.13.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,17 @@
+[tool.poetry]
+name = "y-py"
+version = "0.5.4"
+description = "Python bindings for the Y-CRDT built from yrs (Rust)"
+authors = ["John Waidhofer <waidhoferj@gmail.com>", "Kevin Jahns <kevin.jahns@protonmail.com>", "Pierre-Olivier Simonard <pierre.olivier.simonard@gmail.com>"]
+license = "MIT"
+
+[tool.poetry.dependencies]
+python = "^3.9"
+
+[tool.poetry.dev-dependencies]
+pytest = "^7.2.0"
+maturin = "^0.13.6"
+
 [build-system]
 requires = ["maturin>=0.13,<0.14"]
 build-backend = "maturin"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[metadata]
-license_files = LICENSE

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-import setuptools
-
-setuptools.setup()


### PR DESCRIPTION
Good morning maintainers. This PR for your consideration moves some metadata from `Cargo.toml` to `pyproject.toml`, and adds `maturin` / `pytest` as Python dev dependencies in `pyproject.toml` so that virtualenv management can be handled with `poetry`.

 - `poetry install && poetry run maturin develop && poetry run pytest` for local development 
 - I think `license` will show up in https://pypi.org/project/y-py/ after this (currently does not)
