### PR TITLE
Hatch to manage Python virtualenvs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,11 +34,12 @@ jobs:
           toolchain: stable
           profile: minimal
           default: true
+      - name: Install Hatch
+        run: |
+          pip install hatch
       - name: Build Ypy
         run: |
-          pip install maturin
-          maturin develop
+          hatch run maturin develop
       - name: Run Tests
         run: |
-          pip install pytest
-          pytest
+          hatch run pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,7 @@ jobs:
           pip install hatch
       - name: Build Ypy
         run: |
+          unset CONDA_PREFIX 
           hatch run maturin develop
       - name: Run Tests
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,7 @@
 name = "y-py"
 version = "0.5.4"
 rust-version = "1.58"
-authors = ["John Waidhofer <waidhoferj@gmail.com>", "Kevin Jahns <kevin.jahns@protonmail.com>", "Pierre-Olivier Simonard <pierre.olivier.simonard@gmail.com>"]
 edition = "2018"
-homepage = "https://github.com/y-crdt/ypy"
-repository = "https://github.com/y-crdt/ypy"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ assert value == "hello world!"
 ## Development Setup
 
 0. [Install Rust](https://www.rust-lang.org/tools/install) and [Python](https://www.python.org/downloads/) (consider [pyenv](https://github.com/pyenv/pyenv))
-1. Install [hatch](https://hatch.pypa.io/1.2/install/) (`python -m pip install hatch`)
+1. Install [hatch](https://hatch.pypa.io/latest/install/) (`python -m pip install hatch`)
 2. Create a development build of the library
    
 ```

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ hatch run maturin develop
 
 ## Tests
 
-All tests are located in `/tests`. There is a `test` environment matrix defined in `pyproject.toml` that will run `pytest` against `py37` through `py310`.
+All tests are located in `/tests`. There is a `test` environment matrix defined in `pyproject.toml` that will run `pytest` against `py37` through `py311`.
 
 ```
 hatch run test:pytest

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ assert value == "hello world!"
 1. Install [hatch](https://hatch.pypa.io/latest/install/) (`python -m pip install hatch`)
 2. Create a development build of the library
 
-Make sure to `unset CONDA_PREFIX` if you are in a conda environment.
+*Make sure to `unset CONDA_PREFIX` if you are in a conda environment. If `hatch` is not found on your PATH, you can run `python -m hatch` instead*
 ```
-python -m hatch run maturin develop
+hatch run maturin develop
 ```
 
 ## Tests
@@ -54,7 +54,7 @@ python -m hatch run maturin develop
 All tests are located in `/tests`. You can run them with `pytest`.
 
 ```
-python -m hatch run pytest
+hatch run pytest
 ```
 
 ## Build Ypy :
@@ -62,5 +62,5 @@ python -m hatch run pytest
 Build the library as a wheel and store them in `target/wheels` :
 
 ```
-python -m hatch run maturin build
+hatch run maturin build
 ```

--- a/README.md
+++ b/README.md
@@ -51,15 +51,15 @@ hatch run maturin develop
 
 ## Tests
 
-All tests are located in `/tests`. You can run them with `pytest`.
+All tests are located in `/tests`. There is a `test` environment matrix defined in `pyproject.toml` that will run `pytest` against `py37` through `py310`.
 
 ```
-hatch run pytest
+hatch run test:pytest
 ```
 
 ## Build Ypy :
 
-Build the library as a wheel and store them in `target/wheels` :
+Build the library as a wheel and store them in `target/wheels`:
 
 ```
 hatch run maturin build

--- a/README.md
+++ b/README.md
@@ -39,22 +39,17 @@ assert value == "hello world!"
 
 ## Development Setup
 
-0. [Install Rust](https://www.rust-lang.org/tools/install) and [Python](https://www.python.org/downloads/) 
-  - Some alternative bootstrapping options are [pyenv](https://github.com/pyenv/pyenv) for Python, or using [mamba](https://github.com/conda-forge/miniforge) to `mamba install rust python`.
-1. Install [hatch](https://hatch.pypa.io/latest/install/) (`python -m pip install hatch`)
-2. Create a development build of the library
-
-*Make sure to `unset CONDA_PREFIX` if you are in a conda environment. If `hatch` is not found on your PATH, you can run `python -m hatch` instead*
-```
-hatch run maturin develop
-```
+0. Install [Rust](https://www.rust-lang.org/tools/install) and [Python](https://www.python.org/downloads/)
+1. Install `maturin` in order to build Ypy: `pip install maturin`
+2. Create a development build of the library: `maturin develop`
 
 ## Tests
 
-All tests are located in `/tests`. There is a `test` environment matrix defined in `pyproject.toml` that will run `pytest` against `py37` through `py311`.
+All tests are located in `/tests`. If you are using `hatch`, there is a `test` environment matrix defined in `pyproject.toml` that will run `pytest` against `py37` through `py311`. To run the tests, install `pytest` and run the command line tool from the project root:
 
 ```
-hatch run test:pytest
+pip install pytest
+pytest
 ```
 
 ## Build Ypy :
@@ -62,5 +57,5 @@ hatch run test:pytest
 Build the library as a wheel and store them in `target/wheels`:
 
 ```
-hatch run maturin build
+maturin build
 ```

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ assert value == "hello world!"
 
 ## Development Setup
 
-0. [Install Rust](https://www.rust-lang.org/tools/install) and [Python](https://www.python.org/downloads/) (consider [pyenv](https://github.com/pyenv/pyenv))
+0. [Install Rust](https://www.rust-lang.org/tools/install) and [Python](https://www.python.org/downloads/) 
+  - Some alternative bootstrapping options are [pyenv](https://github.com/pyenv/pyenv) for Python and using [conda](https://conda.io/projects/conda/en/latest/user-guide/install/index.html) to [conda install rust](https://anaconda.org/conda-forge/rust)
 1. Install [hatch](https://hatch.pypa.io/latest/install/) (`python -m pip install hatch`)
 2. Create a development build of the library
    

--- a/README.md
+++ b/README.md
@@ -39,22 +39,20 @@ assert value == "hello world!"
 
 ## Development Setup
 
-0. Install Rust and Python
-1. Install `maturin` in order to build Ypy
-
-```
-pip install maturin
-```
-
+0. [Install Rust](https://www.rust-lang.org/tools/install) and [Python](https://www.python.org/downloads/) (consider [pyenv](https://github.com/pyenv/pyenv))
+1. Install [hatch](https://hatch.pypa.io/1.2/install/) (`python -m pip install hatch`)
 2. Create a development build of the library
-   `maturin develop`
+   
+```
+python -m hatch run maturin develop
+```
 
 ## Tests
 
 All tests are located in `/tests`. You can run them with `pytest`.
 
 ```
-pytest
+python -m hatch run maturin develop
 ```
 
 ## Build Ypy :
@@ -62,5 +60,5 @@ pytest
 Build the library as a wheel and store them in `target/wheels` :
 
 ```
-maturin build
+python -m hatch run maturin build
 ```

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ python -m hatch run maturin develop
 All tests are located in `/tests`. You can run them with `pytest`.
 
 ```
-python -m hatch run maturin develop
+python -m hatch run pytest
 ```
 
 ## Build Ypy :

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ assert value == "hello world!"
 ## Development Setup
 
 0. [Install Rust](https://www.rust-lang.org/tools/install) and [Python](https://www.python.org/downloads/) 
-  - Some alternative bootstrapping options are [pyenv](https://github.com/pyenv/pyenv) for Python and using [conda](https://conda.io/projects/conda/en/latest/user-guide/install/index.html) to [conda install rust](https://anaconda.org/conda-forge/rust)
+  - Some alternative bootstrapping options are [pyenv](https://github.com/pyenv/pyenv) for Python and using [mamba](https://github.com/conda-forge/miniforge) to [mamba install rust](https://github.com/conda-forge/rust-feedstock)
 1. Install [hatch](https://hatch.pypa.io/latest/install/) (`python -m pip install hatch`)
 2. Create a development build of the library
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ assert value == "hello world!"
 ## Development Setup
 
 0. [Install Rust](https://www.rust-lang.org/tools/install) and [Python](https://www.python.org/downloads/) 
-  - Some alternative bootstrapping options are [pyenv](https://github.com/pyenv/pyenv) for Python and using [mamba](https://github.com/conda-forge/miniforge) to [mamba install rust](https://github.com/conda-forge/rust-feedstock)
+  - Some alternative bootstrapping options are [pyenv](https://github.com/pyenv/pyenv) for Python, or using [mamba](https://github.com/conda-forge/miniforge) to `mamba install rust python`.
 1. Install [hatch](https://hatch.pypa.io/latest/install/) (`python -m pip install hatch`)
 2. Create a development build of the library
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ assert value == "hello world!"
   - Some alternative bootstrapping options are [pyenv](https://github.com/pyenv/pyenv) for Python and using [conda](https://conda.io/projects/conda/en/latest/user-guide/install/index.html) to [conda install rust](https://anaconda.org/conda-forge/rust)
 1. Install [hatch](https://hatch.pypa.io/latest/install/) (`python -m pip install hatch`)
 2. Create a development build of the library
-   
+
+Make sure to `unset CONDA_PREFIX` if you are in a conda environment.
 ```
 python -m hatch run maturin develop
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,17 @@
 [build-system]
 requires = ["maturin>=0.13,<0.14"]
 build-backend = "maturin"
+
+[project]
+name = "y-py"
+version = "0.5.4"
+description = "Python bindings for the Y-CRDT built from yrs (Rust)"
+authors = [
+    { name = "John Waidofer", email = "waidhoferj@gmail.com" },
+    { name = "Kevin Jahns", email = "kevin.jahns@protonmail.com" },
+    { name = "Pierre-Olivier Simonard", email = "pierre.olivier.simonard@gmail.com" }
+]
+readme = "README.md"
+homepage = "https://github.com/y-crdt/ypy"
+repository = "https://github.com/y-crdt/ypy"
+dependencies = ["pytest", "maturin"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,4 +17,4 @@ repository = "https://github.com/y-crdt/ypy"
 dependencies = ["pytest", "maturin"]
 
 [[tool.hatch.envs.test.matrix]]
-python = ["37", "38", "39", "310"]
+python = ["37", "38", "39", "310", "311"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "y-py"
 version = "0.5.4"
 description = "Python bindings for the Y-CRDT built from yrs (Rust)"
 authors = [
-    { name = "John Waidofer", email = "waidhoferj@gmail.com" },
+    { name = "John Waidhofer", email = "waidhoferj@gmail.com" },
     { name = "Kevin Jahns", email = "kevin.jahns@protonmail.com" },
     { name = "Pierre-Olivier Simonard", email = "pierre.olivier.simonard@gmail.com" }
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,6 @@ readme = "README.md"
 homepage = "https://github.com/y-crdt/ypy"
 repository = "https://github.com/y-crdt/ypy"
 dependencies = ["pytest", "maturin"]
+
+[[tool.hatch.envs.test.matrix]]
+python = ["37", "38", "39", "310"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[metadata]
-license_files = LICENSE

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-import setuptools
-
-setuptools.setup()


### PR DESCRIPTION
Alternative to, and closes https://github.com/y-crdt/ypy/pull/86 if you prefer this one.

Use `hatch` to manage Python virtualenv when developing instead of manually creating one or re-using a system Python. 

This is what I'm seeing in the wheel metadata after building
![image](https://user-images.githubusercontent.com/3867768/199744540-4c610a56-47cf-46fd-a3c0-f13a96118e48.png)

