### PR TITLE
Add Pypi badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![PyPI version](https://badge.fury.io/py/y-py.svg)](https://badge.fury.io/py/y-py)
+
 # Ypy
 
 Ypy is a Python binding for Y-CRDT. It provides distributed data types that enable real-time collaboration between devices. Ypy can sync data with any other platform that has a Y-CRDT binding, allowing for seamless cross-domain communication. The library is a thin wrapper around Yrs, taking advantage of the safety and performance of Rust.


### PR DESCRIPTION
There's a couple badges I like to have at the top of README's in my repos, thought I'd start with adding in a simple pypi link to see what you all thought of them. Happy to include more in this PR or leave them off the project, either way.

![image](https://user-images.githubusercontent.com/3867768/200415456-ec9c88a1-d692-4f0d-b79c-599a4605b1e1.png)

(`pydantic-core` for comparison as another Python/Rust hybrid repo on pypi -- *to be clear I'm not a contributor there*. The different style/text between the top and bottom picture is a difference in using badge.fury.io vs shield.io, I don't have a real preference between them)
![image](https://user-images.githubusercontent.com/3867768/200415681-b91dbf18-8345-45bc-bb6c-1717317610af.png)
