### PR TITLE
`to_json` compatibility with Python `json`

### DIFF
--- a/src/json_builder.rs
+++ b/src/json_builder.rs
@@ -1,0 +1,152 @@
+use std::{collections::HashMap, convert::TryFrom};
+
+use lib0::any::Any;
+use pyo3::{exceptions::PyTypeError, PyErr, PyObject, PyResult, Python};
+
+use crate::shared_types::{CompatiblePyType, YPyType};
+
+#[derive(Clone, Debug)]
+pub(crate) struct JsonBuilder(String);
+
+impl JsonBuilder {
+    pub fn new() -> Self {
+        JsonBuilder(String::new())
+    }
+
+    pub fn append_json<T: JsonBuildable>(&mut self, buildable: &T) -> Result<(), T::JsonError> {
+        let buffer = &mut self.0;
+        buildable.build_json(buffer)
+    }
+}
+
+impl From<JsonBuilder> for String {
+    fn from(json_builder: JsonBuilder) -> Self {
+        json_builder.0
+    }
+}
+
+pub(crate) trait JsonBuildable {
+    type JsonError;
+    fn build_json(&self, buffer: &mut String) -> Result<(), Self::JsonError>;
+}
+
+impl<'a> JsonBuildable for CompatiblePyType<'a> {
+    type JsonError = PyErr;
+
+    fn build_json(&self, buffer: &mut String) -> Result<(), Self::JsonError> {
+        match self {
+            CompatiblePyType::Bool(b) => {
+                let t: bool = b.extract().unwrap();
+                buffer.push_str(if t { "true" } else { "false" });
+            }
+            CompatiblePyType::Int(i) => buffer.push_str(&i.to_string()),
+            CompatiblePyType::Float(f) => buffer.push_str(&f.to_string()),
+            CompatiblePyType::String(s) => {
+                let string: String = s.extract().unwrap();
+                buffer.reserve(string.len() + 2);
+                buffer.push_str("\"");
+                buffer.push_str(&string);
+                buffer.push_str("\"");
+            }
+            CompatiblePyType::List(list) => {
+                buffer.push_str("[");
+                let length = list.len();
+                for (i, element) in list.iter().enumerate() {
+                    CompatiblePyType::try_from(element)?.build_json(buffer)?;
+                    if i + 1 < length {
+                        buffer.push_str(",");
+                    }
+                }
+
+                buffer.push_str("]");
+            }
+            CompatiblePyType::Dict(dict) => {
+                buffer.push_str("{");
+                let length = dict.len();
+                for (i, (k, v)) in dict.iter().enumerate() {
+                    CompatiblePyType::try_from(k)?.build_json(buffer)?;
+                    buffer.push_str(":");
+                    CompatiblePyType::try_from(v)?.build_json(buffer)?;
+                    if i + 1 < length {
+                        buffer.push_str(",");
+                    }
+                }
+                buffer.push_str("}");
+            }
+            CompatiblePyType::YType(y_type) => y_type.build_json(buffer)?,
+            CompatiblePyType::None => buffer.push_str("null"),
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a> JsonBuildable for YPyType<'a> {
+    type JsonError = PyErr;
+
+    fn build_json(&self, buffer: &mut String) -> Result<(), Self::JsonError> {
+        let json = match self {
+            YPyType::Text(text) => Ok(text.borrow().to_json()),
+            YPyType::Array(array) => array.borrow().to_json(),
+            YPyType::Map(map) => map.borrow().to_json(),
+            xml => Err(PyTypeError::new_err(format!(
+                "XML elements cannot be converted to a JSON format: {xml}"
+            ))),
+        };
+        buffer.push_str(&json?);
+        Ok(())
+    }
+}
+
+impl JsonBuildable for Any {
+    type JsonError = PyErr;
+    fn build_json(&self, buffer: &mut String) -> Result<(), Self::JsonError> {
+        self.to_json(buffer);
+        Ok(())
+    }
+}
+
+impl JsonBuildable for HashMap<String, PyObject> {
+    type JsonError = PyErr;
+
+    fn build_json(&self, buffer: &mut String) -> Result<(), Self::JsonError> {
+        buffer.push_str("{");
+        let res: PyResult<()> = Python::with_gil(|py| {
+            for (i, (k, py_obj)) in self.iter().enumerate() {
+                let value: CompatiblePyType = py_obj.extract(py)?;
+                if i != 0 {
+                    buffer.push_str(",");
+                }
+                buffer.push_str(k);
+                buffer.push_str(":");
+                value.build_json(buffer)?;
+            }
+            Ok(())
+        });
+        res?;
+
+        buffer.push_str("}");
+        Ok(())
+    }
+}
+
+impl JsonBuildable for Vec<PyObject> {
+    type JsonError = PyErr;
+
+    fn build_json(&self, buffer: &mut String) -> Result<(), Self::JsonError> {
+        buffer.push_str("[");
+        let res: PyResult<()> = Python::with_gil(|py| {
+            self.iter().enumerate().try_for_each(|(i, object)| {
+                let py_type: CompatiblePyType = object.extract(py)?;
+                if i != 0 {
+                    buffer.push_str(",");
+                }
+                py_type.build_json(buffer)?;
+                Ok(())
+            })
+        });
+        res?;
+        buffer.push_str("]");
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
+mod json_builder;
 mod shared_types;
 mod type_conversions;
 mod y_array;

--- a/src/type_conversions.rs
+++ b/src/type_conversions.rs
@@ -14,7 +14,8 @@ use yrs::types::Events;
 use yrs::types::{Attrs, Branch, BranchPtr, Change, Delta, EntryChange, Value};
 use yrs::{Array, Map, Text, Transaction};
 
-use crate::shared_types::{Shared, SharedType};
+use crate::shared_types::CompatiblePyType;
+use crate::shared_types::{SharedType, YPyType};
 use crate::y_array::YArray;
 use crate::y_array::YArrayEvent;
 use crate::y_map::YMap;
@@ -31,7 +32,7 @@ pub trait ToPython {
     fn into_py(self, py: Python) -> PyObject;
 }
 
-impl ToPython for Vec<Any> {
+impl<T: ToPython> ToPython for Vec<T> {
     fn into_py(self, py: Python) -> PyObject {
         let elements = self.into_iter().map(|v| v.into_py(py));
         let arr: PyObject = pyo3::types::PyList::new(py, elements).into();
@@ -52,6 +53,41 @@ where
         py_dict.into_py(py)
     }
 }
+
+impl<'a> TryFrom<&'a PyAny> for CompatiblePyType<'a> {
+    type Error = PyErr;
+
+    fn try_from(py_any: &'a PyAny) -> Result<Self, Self::Error> {
+        if let Ok(b) = py_any.downcast::<pytypes::PyBool>() {
+            Ok(Self::Bool(b))
+        } else if let Ok(i) = py_any.downcast::<pytypes::PyInt>() {
+            Ok(Self::Int(i))
+        } else if py_any.is_none() {
+            Ok(Self::None)
+        } else if let Ok(f) = py_any.downcast::<pytypes::PyFloat>() {
+            Ok(Self::Float(f))
+        } else if let Ok(s) = py_any.downcast::<pytypes::PyString>() {
+            Ok(Self::String(s))
+        } else if let Ok(list) = py_any.downcast::<pytypes::PyList>() {
+            Ok(Self::List(list))
+        } else if let Ok(dict) = py_any.downcast::<pytypes::PyDict>() {
+            Ok(Self::Dict(dict))
+        } else if let Ok(v) = YPyType::try_from(py_any) {
+            Ok(Self::YType(v))
+        } else {
+            Err(PyTypeError::new_err(format!(
+                "Cannot integrate this type into a YDoc: {py_any}"
+            )))
+        }
+    }
+}
+
+impl<'a> FromPyObject<'a> for CompatiblePyType<'a> {
+    fn extract(ob: &'a PyAny) -> PyResult<Self> {
+        Self::try_from(ob)
+    }
+}
+
 
 impl ToPython for Delta {
     fn into_py(self, py: Python) -> PyObject {
@@ -147,26 +183,73 @@ impl<'a> IntoPy<PyObject> for EntryChangeWrapper<'a> {
 #[repr(transparent)]
 pub(crate) struct PyObjectWrapper(pub PyObject);
 
+impl From<PyObject> for PyObjectWrapper {
+    fn from(value: PyObject) -> Self {
+        PyObjectWrapper(value)
+    }
+}
+
+impl Deref for PyObjectWrapper {
+    type Target = PyObject;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 impl Prelim for PyObjectWrapper {
+    fn into_content(self, txn: &mut Transaction) -> (ItemContent, Option<Self>) {
+        Python::with_gil(|py| {
+            let valid_type: CompatiblePyType = self.0.extract(py).unwrap_or_else(|err| {
+                err.restore(py);
+                CompatiblePyType::None
+            });
+            let (item_content, py_any) = valid_type.into_content(txn);
+            let wrapper: Option<Self> = py_any.map(|py_type| PyObjectWrapper(py_type.into()));
+            (item_content, wrapper)
+        })
+    }
+
+    fn integrate(self, txn: &mut Transaction, inner_ref: BranchPtr) {
+        Python::with_gil(|py| {
+            let valid_type: CompatiblePyType = self.0.extract(py).unwrap_or_else(|err| {
+                err.restore(py);
+                CompatiblePyType::None
+            });
+            valid_type.integrate(txn, inner_ref);
+        })
+    }
+}
+
+impl<'a> From<CompatiblePyType<'a>> for PyObject {
+    fn from(value: CompatiblePyType<'a>) -> Self {
+        match value {
+            CompatiblePyType::Bool(b) => b.into(),
+            CompatiblePyType::Int(i) => i.into(),
+            CompatiblePyType::Float(f) => f.into(),
+            CompatiblePyType::String(s) => s.into(),
+            CompatiblePyType::List(list) => list.into(),
+            CompatiblePyType::Dict(dict) => dict.into(),
+            CompatiblePyType::YType(y_type) => y_type.into(),
+            CompatiblePyType::None => Python::with_gil(|py| py.None()),
+        }
+    }
+}
+
+impl<'a> Prelim for CompatiblePyType<'a> {
     fn into_content(self, _txn: &mut Transaction) -> (ItemContent, Option<Self>) {
-        let content = match PyObjectWrapper(self.0.clone()).try_into() {
-            Ok(any) => ItemContent::Any(vec![any]),
-            Err(err) => {
-                if Python::with_gil(|py| err.is_instance_of::<MultipleIntegrationError>(py)) {
-                    let shared = Shared::try_from(self.0.clone()).unwrap();
-                    if shared.is_prelim() {
-                        let branch = Branch::new(shared.type_ref(), None);
-                        ItemContent::Type(branch)
-                    } else {
-                        Python::with_gil(|py| err.restore(py));
-                        ItemContent::Any(vec![])
-                    }
-                } else {
-                    Python::with_gil(|py| err.restore(py));
-                    ItemContent::Any(vec![])
-                }
+        let content = match self.clone() {
+            CompatiblePyType::YType(y_type) if y_type.is_prelim() => {
+                let branch = Branch::new(y_type.type_ref(), None);
+                Ok(ItemContent::Type(branch))
             }
+            py_value => Any::try_from(py_value).map(|any| ItemContent::Any(vec![any])),
         };
+
+        let content = content.unwrap_or_else(|err| {
+            Python::with_gil(|py| err.restore(py));
+            ItemContent::Any(vec![])
+        });
 
         let this = if let ItemContent::Type(_) = &content {
             Some(self)
@@ -178,97 +261,128 @@ impl Prelim for PyObjectWrapper {
     }
 
     fn integrate(self, txn: &mut Transaction, inner_ref: BranchPtr) {
-        if let Ok(shared) = Shared::try_from(self.0) {
-            if shared.is_prelim() {
-                Python::with_gil(|py| {
-                    match shared {
-                    Shared::Text(v) => {
+        match self {
+            CompatiblePyType::YType(y_type) if y_type.is_prelim() => {
+                match y_type {
+                    YPyType::Text(v) => {
                         let text = Text::from(inner_ref);
-                        let mut y_text = v.borrow_mut(py);
+                        let mut y_text = v.borrow_mut();
 
                         if let SharedType::Prelim(v) = y_text.0.to_owned() {
                             text.push(txn, v.as_str());
                         }
                         y_text.0 = SharedType::Integrated(text.clone());
                     }
-                    Shared::Array(v) => {
+                    YPyType::Array(v) => {
                         let array = Array::from(inner_ref);
-                        let mut y_array = v.borrow_mut(py);
+                        let mut y_array = v.borrow_mut();
                         if let SharedType::Prelim(items) = y_array.0.to_owned() {
                             let len = array.len();
                             YArray::insert_multiple_at(&array, txn, len, items);
                         }
                         y_array.0 = SharedType::Integrated(array.clone());
                     }
-                    Shared::Map(v) => {
+                    YPyType::Map(v) => {
                         let map = Map::from(inner_ref);
-                        let mut y_map = v.borrow_mut(py);
-                        if let SharedType::Prelim(entries) = y_map.0.to_owned() {
-                            for (k, v) in entries {
-                                map.insert(txn, k, PyObjectWrapper(v));
+                        let mut y_map = v.borrow_mut();
+                        Python::with_gil(|py| {
+                            if let SharedType::Prelim(ref entries) = y_map.0 {
+                                for (k, v) in entries {
+                                    let x: CompatiblePyType = v.extract(py).unwrap_or_else(|err| {
+                                        err.restore(py);
+                                        CompatiblePyType::None
+                                    });
+                                    map.insert(txn, k.to_owned(), x);
+                                }
                             }
-                        }
+                        });
+                        
                         y_map.0 = SharedType::Integrated(map.clone());
                     }
-                    Shared::XmlElement(_) | Shared::XmlText(_) => unreachable!("As defined in Shared::is_prelim(), neither XML type can ever exist outside a YDoc"),
+                    YPyType::XmlElement(_) | YPyType::XmlText(_) => unreachable!("As defined in Shared::is_prelim(), neither XML type can ever exist outside a YDoc"),
                 }
-                })
             }
+            _ => ()
         }
     }
 }
 
-impl TryFrom<PyObjectWrapper> for Any {
+impl<'a> TryFrom<CompatiblePyType<'a>> for Any {
     type Error = PyErr;
 
-    fn try_from(wrapper: PyObjectWrapper) -> Result<Self, Self::Error> {
+    fn try_from(py_type: CompatiblePyType<'a>) -> Result<Self, Self::Error> {
         const MAX_JS_NUMBER: i64 = 2_i64.pow(53) - 1;
-        let py_obj = wrapper.0;
-        Python::with_gil(|py| {
-            let v = py_obj.as_ref(py);
-
-            if let Ok(b) = v.downcast::<pytypes::PyBool>() {
-                Ok(Any::Bool(b.extract().unwrap()))
-            } else if let Ok(l) = v.downcast::<pytypes::PyInt>() {
-                let num: i64 = l.extract().unwrap();
+        match py_type {
+            CompatiblePyType::Bool(b) => Ok(Any::Bool(b.extract()?)),
+            CompatiblePyType::String(s) => Ok(Any::String(s.extract::<String>()?.into_boxed_str())),
+            CompatiblePyType::Int(i) => {
+                let num: i64 = i.extract()?;
                 if num > MAX_JS_NUMBER {
                     Ok(Any::BigInt(num))
                 } else {
                     Ok(Any::Number(num as f64))
                 }
-            } else if v.is_none() {
-                Ok(Any::Null)
-            } else if let Ok(f) = v.downcast::<pytypes::PyFloat>() {
-                Ok(Any::Number(f.extract().unwrap()))
-            } else if let Ok(s) = v.downcast::<pytypes::PyString>() {
-                let string: String = s.extract().unwrap();
-                Ok(Any::String(string.into_boxed_str()))
-            } else if let Ok(list) = v.downcast::<pytypes::PyList>() {
-                let result: PyResult<Vec<Any>> = list
+            }
+            CompatiblePyType::Float(f) => Ok(Any::Number(f.extract()?)),
+            CompatiblePyType::List(l) => {
+                let result: PyResult<Vec<Any>> = l
                     .into_iter()
-                    .map(|py_val| PyObjectWrapper(py_val.into()).try_into())
+                    .map(|py_any|CompatiblePyType::try_from(py_any)?.try_into())
                     .collect();
                 result.map(|res| Any::Array(res.into_boxed_slice()))
-            } else if let Ok(dict) = v.downcast::<pytypes::PyDict>() {
-                let result: PyResult<HashMap<String, Any>> = dict
+            },
+            CompatiblePyType::Dict(d) => {
+                let result: PyResult<HashMap<String, Any>> = d
                     .iter()
                     .map(|(k, v)| {
                         let key: String = k.extract()?;
-                        let value = PyObjectWrapper(v.into()).try_into()?;
+                        let value = CompatiblePyType::try_from(v)?.try_into()?;
                         Ok((key, value))
                     })
                     .collect();
                 result.map(|res| Any::Map(Box::new(res)))
-            } else if let Ok(v) = Shared::try_from(PyObject::from(v)) {
-                Err(MultipleIntegrationError::new_err(format!(
+            },
+            CompatiblePyType::None => Ok(Any::Null),
+            CompatiblePyType::YType(v) => Err(MultipleIntegrationError::new_err(format!(
                     "Cannot integrate a nested Ypy object because is already integrated into a YDoc: {v}"
-                )))
-            } else {
-                Err(PyTypeError::new_err(format!(
-                    "Cannot integrate this type into a YDoc: {v}"
-                )))
-            }
-        })
+                ))),
+        }
+    }
+}
+
+impl<'a> FromPyObject<'a> for YPyType<'a> {
+    fn extract(ob: &'a PyAny) -> PyResult<Self> {
+        Self::try_from(ob)
+    }
+}
+
+impl<'a> From<YPyType<'a>> for PyObject {
+    fn from(value: YPyType<'a>) -> Self {
+        match value {
+            YPyType::Text(text) => text.into(),
+            YPyType::Array(array) => array.into(),
+            YPyType::Map(map) => map.into(),
+            YPyType::XmlElement(xml) => xml.into(),
+            YPyType::XmlText(xml) => xml.into(),
+        }
+    }
+}
+
+impl<'a> TryFrom<&'a PyAny> for YPyType<'a> {
+    type Error = PyErr;
+
+    fn try_from(value: &'a PyAny) -> Result<Self, Self::Error> {
+        if let Ok(text) = value.extract() {
+            Ok(YPyType::Text(text))
+        } else if let Ok(array) = value.extract() {
+            Ok(YPyType::Array(array))
+        } else if let Ok(map) = value.extract() {
+            Ok(YPyType::Map(map))
+        } else {
+            Err(pyo3::exceptions::PyValueError::new_err(
+                format!("Could not extract a Ypy type from this object: {value}")
+            ))
+        }
     }
 }
 

--- a/tests/test_y_doc.py
+++ b/tests/test_y_doc.py
@@ -41,7 +41,7 @@ def test_encoding():
     state_vec = Y.encode_state_vector(receiver)
     update = Y.encode_state_as_update(doc, state_vec)
     Y.apply_update(receiver, update)
-    value = receiver.get_array("test").to_json()
+    value = list(receiver.get_array("test"))
     assert value == contents
 
 
@@ -59,7 +59,7 @@ def test_boolean_encoding():
     state_vec = Y.encode_state_vector(receiver)
     update = Y.encode_state_as_update(doc, state_vec)
     Y.apply_update(receiver, update)
-    value = receiver.get_array("test").to_json()
+    value = list(receiver.get_array("test"))
     assert type(value[0]) == type(True)
 
 

--- a/y_py.pyi
+++ b/y_py.pyi
@@ -552,7 +552,7 @@ class YArray:
         Returns:
             The string representation of YArray wrapped in `YArray()`
         """
-    def to_json(self) -> List[Any]:
+    def to_json(self) -> str:
         """
         Converts an underlying contents of this `YArray` instance into their JSON representation.
         """
@@ -725,12 +725,19 @@ class YMap:
         Returns:
             The string representation of the `YMap`.
         """
+
+    def __dict__(self) -> dict:
+         """
+        Returns:
+            Contents of the `YMap` inside a Python dictionary.
+        """
+
     def __repr__(self) -> str:
         """
         Returns:
             The string representation of the `YMap` wrapped in 'YMap()'
         """
-    def to_json(self) -> dict:
+    def to_json(self) -> str:
         """
         Converts contents of this `YMap` instance into a JSON representation.
         """


### PR DESCRIPTION
Updates `to_json` methods to return `str` types so that they can be used with Python `json`

Fixes #85 

## Changes
- Separated type validation into `CompatiblePyType`, which validates incoming Python types to ensure they can be represented in the YCRDT.
- Added `JsonBuilder`, which can append json from any `JsonBuildable` object to a string buffer.
- Updated tests to cover `to_json` conversion.
- Changed `YArray` iterator method to return a PyIterator on eagerly evaluated array contents.

## Type Conversion Best Practices
In the past, we used `to_json` as a conversion to native Python types. In the future, we should use the direct constructor of the type we desire:
```python
python_list = list(y_array)
python_dict = dict(y_map)
python_string = str(y_text)
```
Note that this is not a deep conversion.

### `YArray` Iterator Update
This addresses an unknown bug associated with the move behavior. While move works correctly when we pull the `Any` representation directly from the Yrs `Array`, the iterator from the raw pointer seems to move with the moved element.

```python
doc = YDoc()
    arr = doc.get_array('test')

    # Move 9 to 0
    with doc.begin_transaction() as t:
        arr.delete_range(t, 0, len(arr))
        arr.extend(t, [0,1,2,3,4,5,6,7,8,9])
    doc.transact(lambda t: arr.move_to(t, 9, 0))
    assert arr.to_json() == '[9,0,1,2,3,4,5,6,7,8]' # passes
    assert list(arr) == [9,0,1,2,3,4,5,6,7,8] # fails returning [9.0]
```

While this eager evaluation isn't ideal, it does match the expected behavior in `y-wasm` and fixes a significant bug with the move feature.
