### PR TITLE
pin wasm wheel runner to ubuntu-20.04

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -98,7 +98,7 @@ jobs:
           path: dist
 
   wasm:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     # Pyodide began supporting `micropip.install` from emscripten-compiled binary wheels
     # in Pyodide 0.21.0 (Aug 2022), so no need to build wheels for versions before then.
     # As of Nov 2022, the matrix for emscripten/python versions since then is simple. 


### PR DESCRIPTION
When `ubuntu-latest` resolves to `ubuntu-22.04`, it fails to checkout Python 3.10.2 (https://github.com/y-crdt/ypy/actions/runs/3687267693/jobs/6240630198#step:3:10). I think it's best to try and build with 3.10.2 to match Pyodide. Workaround is to pin this task to `ubuntu-20.04` runner, which works. Maybe a future Pyodide release will be built with a Python version that lines up with `ubuntu-22.04` Python targets.