### PR TITLE
Filter Empty Updates from `YDoc.observe_after_transaction`

### DIFF
--- a/src/y_doc.rs
+++ b/src/y_doc.rs
@@ -168,12 +168,14 @@ impl YDoc {
     pub fn observe_after_transaction(&mut self, callback: PyObject) -> SubscriptionId {
         self.0
             .observe_transaction_cleanup(move |txn, event| {
-                Python::with_gil(|py| {
-                    let event = AfterTransactionEvent::new(event, txn);
-                    if let Err(err) = callback.call1(py, (event,)) {
-                        err.restore(py)
-                    }
-                })
+                if event.before_state != event.after_state {
+                    Python::with_gil(|py| {
+                        let event = AfterTransactionEvent::new(event, txn);
+                        if let Err(err) = callback.call1(py, (event,)) {
+                            err.restore(py)
+                        }
+                    })
+                }
             })
             .into()
     }


### PR DESCRIPTION
Fixes #98

`observe_after_transaction` callbacks should only trigger if there are contentful updates to the CRDT. There are certain [operations](https://github.com/Waidhoferj/ypy/blob/178a2f5525d8a0739a3eafb16e724dd577e66654/tests/test_y_doc.py#L148) that need a `YTransaction` to complete, but don't mutate any underlying state. This caused empty updates in `observe_after_transaction`, which is a meaningless event.

To avoid propagating these noops, @davidbrochart and I added this boilerplate to our callbacks:
```python
def send_updates(self, txn_event: Y.AfterTransactionEvent):
        update = txn_event.get_update()
        if update != b'\x00\x00':
            send_update(update) 
```

Since we expect this behavior across the board, this PR filters out empty updates before the callback is triggered, so we will no longer have to add this check on a per-case basis.
