### PR TITLE
Wheel builds for aarch64 and others

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,6 +1,9 @@
 name: Build and Release
 
 on:
+  push:
+    branches:
+      - build_aarch64
   release:
     types: [published]
 
@@ -16,7 +19,12 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.11"]
+        python-version:
+          - '3.7'
+          - '3.8'
+          - '3.9'
+          - '3.10'
+          - '3.11'
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -49,7 +57,12 @@ jobs:
     strategy:
       matrix:
         target: [x64, x86]
-        python-version: ["3.7", "3.11"]
+        python-version:
+          - '3.7'
+          - '3.8'
+          - '3.9'
+          - '3.10'
+          - '3.11'
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -78,7 +91,12 @@ jobs:
     strategy:
       matrix:
         target: [x86_64, i686]
-        python-version: ["3.7", "3.11"]
+        python-version:
+          - '3.7'
+          - '3.8'
+          - '3.9'
+          - '3.10'
+          - '3.11'
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -96,6 +114,33 @@ jobs:
         with:
           name: wheels
           path: dist
+
+  linux-cross:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          - '3.7'
+          - '3.8'
+          - '3.9'
+          - '3.10'
+          - '3.11'
+        target: [aarch64, armv7, s390x, ppc64le]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build Wheels
+      uses: PyO3/maturin-action@v1
+      with:
+        target: ${{ matrix.target }}
+        manylinux: auto
+        args: -i ${{ matrix.python-version }} --release --out dist
+
+    - name: Upload wheels
+      uses: actions/upload-artifact@v3
+      with:
+        name: wheels
+        path: dist
 
   wasm:
     runs-on: ubuntu-20.04

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,9 +1,6 @@
 name: Build and Release
 
 on:
-  push:
-    branches:
-      - build_aarch64
   release:
     types: [published]
 


### PR DESCRIPTION
Closes https://github.com/y-crdt/ypy/issues/114

https://github.com/PyO3/maturin-action has couple of links to CI files for other projects that build wheels with maturin. I thought https://github.com/milesgranger/pyrus-cramjam/blob/master/.github/workflows/CI.yml and https://github.com/messense/py-dissimilar/blob/main/.github/workflows/CI.yml looked really clean in particular.  The `py-dissimilar` CI looks like it builds all the linux and linux-cross python versions in one run but when I tried that I got an error saying maturin couldn't find an interpreter (https://github.com/kafonek/ypy/actions/runs/4093394652/jobs/7058804065 vs one of their working runs https://github.com/messense/py-dissimilar/actions/runs/3968643400/jobs/6802077215)

I think running tests on the built wheels is a good idea, but leaving that for a follow-up PR. I also think adding y-py to the maturin-actions readme would be cool. I can put in that PR if you all are good with it.

Lastly, I want to say `python-version: ["3.7", "3.11"]` actually skips building wheels for 3.8, 3.9, 3.10? Or is there some magic in the github action matrix syntax that makes this work?