### PR TITLE
Bump version to create github v0.5.8 release and upload pypi wheels?

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "y-py"
-version = "0.5.5"
+version = "0.5.8"
 description = "Python bindings for the Y-CRDT built from yrs (Rust)"
 authors = [
     { name = "John Waidhofer", email = "waidhoferj@gmail.com" },


### PR DESCRIPTION
The v0.5.7 github release built wheels correctly (thank goodness, finally) but parts of the push to pypi failed because pyproject.toml version was still 0.5.5 and there were wheels on pypi for 0.5.5 already https://github.com/y-crdt/ypy/actions/runs/4188025953/jobs/7259030230. There are now some y_py 0.5.5 wheels uploaded Dec 13 2022 and (the new aarch64) wheels uploaded Feb 15 2023 https://pypi.org/project/y-py/0.5.5/#files. 

One option is to bump the version in pyproject.toml from 0.5.5 to 0.5.8 so that we don't have to delete and recreate releases in github -- there would just be "missing" wheels on p ypi for 0.5.6 / 0.5.7. @Waidhoferj I'm also fine if you want to close this PR, delete the previous github releases, bump pyproject.toml to 0.5.6 and recreate the github v0.5.6 release.

Thanks.