### PR TITLE
Add license to cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "y-py"
 version = "0.5.5"
 rust-version = "1.58"
 edition = "2018"
+license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Fixes #121 
Added license to `cargo.toml` according to [here](https://www.maturin.rs/metadata.html#add-spdx-license-expressions). 
However, I'm unsure how PyPI selects the license information in the metadata. While the license is correctly displayed in the built wheels, I am uncertain if this is sufficient for PyPI to recognize the license. We may have to wait for a version update to confirm this.
```
(base) (i386)  ➜  ~/code/ypy git:(main) maturin build
📦 Including license file "/Users/yuxlu/code/ypy/LICENSE"
🔗 Found pyo3 bindings
🐍 Found CPython 3.9 at /Users/yuxlu/miniconda3/bin/python3
💻 Using `MACOSX_DEPLOYMENT_TARGET=10.7` for x86_64-apple-darwin by default
    Finished dev [unoptimized + debuginfo] target(s) in 0.05s
📖 Found type stub file at y_py.pyi
📦 Built wheel for CPython 3.9 to /Users/yuxlu/code/ypy/target/wheels/y_py-0.5.5-cp39-cp39-macosx_10_7_x86_64.whl
(base) (i386)  ➜  ~/code/ypy git:(main) cd target/wheels
(base) (i386)  ➜  ~/code/ypy/target/wheels git:(main) unzip y_py-0.5.5-cp39-cp39-macosx_10_7_x86_64.whl
  inflating: y_py-0.5.5.dist-info/METADATA
  inflating: y_py-0.5.5.dist-info/WHEEL
  inflating: y_py-0.5.5.dist-info/license_files/LICENSE
  inflating: y_py/__init__.py
  inflating: y_py/__init__.pyi
  inflating: y_py/py.typed
  inflating: y_py/y_py.cpython-39-darwin.so
  inflating: y_py-0.5.5.dist-info/RECORD
(base) (i386)  ➜  ~/code/ypy/target/wheels git:(main) cat y_py-0.5.5.dist-info/METADATA | grep MIT
License: MIT
```