### PR TITLE
Preliminary Array Insertion

### DIFF
--- a/src/type_conversions.rs
+++ b/src/type_conversions.rs
@@ -278,7 +278,7 @@ impl<'a> Prelim for CompatiblePyType<'a> {
                         let mut y_array = v.borrow_mut();
                         if let SharedType::Prelim(items) = y_array.0.to_owned() {
                             let len = array.len();
-                            YArray::insert_multiple_at(&array, txn, len, items);
+                            YArray::insert_multiple_at(&array, txn, len, items).unwrap();
                         }
                         y_array.0 = SharedType::Integrated(array.clone());
                     }

--- a/tests/test_y_array.py
+++ b/tests/test_y_array.py
@@ -26,6 +26,18 @@ def test_inserts():
 
     assert list(x) == expected
 
+    # Ensure that preliminary types can be inserted
+    integrated_array = d1.get_array("prelim_container")
+    inserted_prelim = YArray(["insert"])
+    extended_prelim = YArray(["extend"])
+
+    with d1.begin_transaction() as txn:
+        integrated_array.insert(txn,0,inserted_prelim)
+        integrated_array.extend(txn, [extended_prelim])
+    values = [list(a) for a in integrated_array]
+    assert values == [["insert"], ["extend"]]
+
+
 
 def test_to_string():
     arr = YArray([7, "awesome", True, ["nested"], {"testing": "dicts"}])


### PR DESCRIPTION
Fixes #126

`YArray.extend` works with preliminary YTypes once again!

## Changes
- Updated `YArray::insert_multiple_at` to correctly check for preliminary types and gracefully handle errors.

## Testing
- Updated `test_inserts` in test_y_array.py to ensure insertions and extensions work with preliminary types.