### PR TITLE
Update pyo3 to 0.19.2 and add Python 3.12 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.7", "3.11"] # Empty string will trigger a build with the latest python version
+        python-version: ["3.7", "3.11". "3.12"] # Empty string will trigger a build with the latest python version
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -26,7 +26,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: x86_64
-          args: --release --out dist --sdist -i 3.7 3.8 3.9 3.10 3.11 pypy3.8 pypy3.9
+          args: --release --out dist --sdist -i 3.7 3.8 3.9 3.10 3.11 3.12 pypy3.8 pypy3.9
       - name: Test built wheel - x86_64
         run: |
           pip install y-py --no-index --find-links dist --force-reinstall
@@ -35,7 +35,7 @@ jobs:
       - name: Build wheels - universal2
         uses: PyO3/maturin-action@v1
         with:
-          args: --release --universal2 --out dist -i 3.8 3.9 3.10 3.11 pypy3.8 pypy3.9
+          args: --release --universal2 --out dist -i 3.8 3.9 3.10 3.11 3.12 pypy3.8 pypy3.9
       - name: Test built wheel - universal2
         run: |
           pip install y-py --no-index --find-links dist --force-reinstall
@@ -53,9 +53,9 @@ jobs:
       matrix:
         platform:
           - target: x64
-            interpreter: 3.7 3.8 3.9 3.10 3.11
+            interpreter: 3.7 3.8 3.9 3.10 3.11 3.12
           - target: x86
-            interpreter: 3.7 3.8 3.9 3.10 3.11
+            interpreter: 3.7 3.8 3.9 3.10 3.11 3.12
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -96,7 +96,7 @@ jobs:
           rust-toolchain: stable
           target: ${{ matrix.target }}
           manylinux: auto
-          args: --release --out dist -i 3.7 3.8 3.9 3.10 3.11 pypy3.8 pypy3.9
+          args: --release --out dist -i 3.7 3.8 3.9 3.10 3.11 3.12 pypy3.8 pypy3.9
       - name: Test built wheel
         if: matrix.target == 'x86_64'
         run: |
@@ -125,7 +125,7 @@ jobs:
           rust-toolchain: stable
           target: ${{ matrix.target }}
           manylinux: auto
-          args: --release --out dist -i 3.7 3.8 3.9 3.10 3.11 pypy3.8 pypy3.9
+          args: --release --out dist -i 3.7 3.8 3.9 3.10 3.11 3.12 pypy3.8 pypy3.9
 
       - uses: uraimo/run-on-arch-action@v2.3.0
         if: matrix.target != 'ppc64'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ lib0 = "0.12.2"
 yrs = "0.12.2"
 
 [dependencies.pyo3]
-version = "0.16.5"
+version = "0.19.2"
 features = ["extension-module"]

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ pytest
 
 ## Using Hatch
 
-If you are using `hatch`, there is a `test` environment matrix defined in `pyproject.toml` that will run commands in virtual environments for `py37` through `py311`.
+If you are using `hatch`, there is a `test` environment matrix defined in `pyproject.toml` that will run commands in virtual environments for `py37` through `py312`.
 
 ```
 hatch run test:maturin develop

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Rust",
 ]
 
@@ -38,4 +39,4 @@ Pypi = "https://pypi.org/project/y-py"
 dependencies = ["pytest", "maturin"]
 
 [[tool.hatch.envs.test.matrix]]
-python = ["37", "38", "39", "310", "311"]
+python = ["37", "38", "39", "310", "311", "312"]


### PR DESCRIPTION
All tests are passing as before for all Pythons including 3.12. There is only one compile-time warning:

```
warning: calls to `std::mem::drop` with a reference instead of an owned value does nothing
   --> src/y_transaction.rs:263:9
    |
263 |         drop(self);
    |         ^^^^^----^
    |              |
    |              argument has type `&mut YTransaction`
    |
    = note: use `let _ = ...` to ignore the expression or result
    = note: `#[warn(dropping_references)]` on by default

warning: `y-py` (lib) generated 1 warning
    Finished dev [unoptimized + debuginfo] target(s) in 7.00s
```

but the same was there also with the previous version of pyo3.

Fixes: #137 