### PR TITLE
Remove drop reference

### DIFF
--- a/src/y_transaction.rs
+++ b/src/y_transaction.rs
@@ -260,7 +260,6 @@ impl YTransaction {
         _traceback: Option<&'p PyAny>,
     ) -> PyResult<bool> {
         self.commit();
-        drop(self);
         Ok(exception_type.is_none())
     }
 }


### PR DESCRIPTION
The `drop(self)` issues a warning:
```
warning: calls to `std::mem::drop` with a reference instead of an owned value does nothing
   --> src/y_transaction.rs:263:9
    |
263 |         drop(self);
    |         ^^^^^----^
    |              |
    |              argument has type `&mut YTransaction`
    |
    = note: use `let _ = ...` to ignore the expression or result
    = note: `#[warn(dropping_references)]` on by default
```